### PR TITLE
feat: adds command to mark region as reviewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See the [Build and install](#build-and-install) section below for how to build a
 
 -   [**Findings and Notes**](#findings-and-notes) - Bookmark regions of code to identify findings or to add audit notes.
 -   [**Audited Files**](#audited-files) - Mark an entire file as reviewed.
+-   [**Partially Audited Files**](#partially-audited-files) - Mark a region of code as reviewed.
 -   [**Detailed Findings**](#detailed-findings) - Fill detailed information about a finding.
 -   [**Github Issues**](#github-issues) - Create formatted Github issues with the Detailed Findings information.
 -   [**Multi-region Findings**](#multi-region-findings) - Group multiple locations under a single finding.
@@ -54,6 +55,21 @@ The highlighted colors can be customized in the [settings](#settings).
 After reviewing a file, you can mark it as audited by calling the `weAudit: Mark File as Reviewed` command, or its respective keyboard shortcut. The whole file will be highlighted and annotated with a `✓` in the file tree, and in the file name above the editor.
 
 ![Mark File as Reviewed](media/readme/gifs/mark_audited.gif)
+
+The highlighted color can be customized in the [settings](#settings).
+
+### Partially Audited Files
+
+You can also partially mark a file as reviewed by selecting a region of code and calling the `weAudit: Mark Region as Reviewed` command. Partially reviewed regions can be merged together by calling the same command on a region containing.
+If called on a region:
+ - that matches an already audited region, the region will be unmarked.
+ - containing an already audited region, the region will be extended.
+ - contained in an already audited region, the region will be split into two regions.
+
+Once a file is marked as audited with the `weAudit: Mark File as Reviewed` command, all partial regions will be discarded.
+
+The following gif showcases all the scenarios described:
+![Mark Region as Reviewed](media/readme/gifs/mark_region_audited.gif)
 
 The highlighted color can be customized in the [settings](#settings).
 
@@ -148,7 +164,8 @@ You can configure the keybindings to any of the extension's commands in the VSCo
 -   `weAudit.deleteLocationUnderCursor`: Delete Finding Under Cursor: `cmd + 5`
 -   `weAudit.editEntryUnderCursor`: Edit Finding Under Cursor: `cmd + 6`
 -   `weAudit.toggleAudited`: Mark Current File As Reviewed: `cmd + 7`
--   Copy Permalink (for the Selected Code Region): `cmd + 8`
+-   `weAudit.addPartiallyAudited`: Mark Region As Reviewed: `cmd + shift + 7`
+-   `weAudit.copySelectedCodePermalink`: Copy Permalink (for the Selected Code Region): `cmd + 8`
 
 ## WeAudit Concepts
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
                 "title": "weAudit: Mark File as Reviewed"
             },
             {
-                "command": "weAudit.addPartialAudited",
+                "command": "weAudit.addpartiallyAudited",
                 "title": "weAudit: Mark Region as Reviewed"
             },
             {
@@ -212,7 +212,7 @@
                 "mac": "cmd+7"
             },
             {
-                "command": "weAudit.addPartialAudited",
+                "command": "weAudit.addpartiallyAudited",
                 "key": "ctrl+shift+7",
                 "mac": "cmd+shift+7"
             },

--- a/package.json
+++ b/package.json
@@ -167,6 +167,10 @@
                 "title": "weAudit: Mark File as Reviewed"
             },
             {
+                "command": "weAudit.addPartialAudited",
+                "title": "weAudit: Mark Region as Reviewed"
+            },
+            {
                 "command": "weAudit.addFinding",
                 "title": "weAudit: New Finding from Selection"
             },
@@ -206,6 +210,11 @@
                 "command": "weAudit.toggleAudited",
                 "key": "ctrl+alt+7",
                 "mac": "cmd+7"
+            },
+            {
+                "command": "weAudit.addPartialAudited",
+                "key": "ctrl+shift+7",
+                "mac": "cmd+shift+7"
             },
             {
                 "command": "weAudit.addFinding",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
                 "title": "weAudit: Mark File as Reviewed"
             },
             {
-                "command": "weAudit.addpartiallyAudited",
+                "command": "weAudit.addPartiallyAudited",
                 "title": "weAudit: Mark Region as Reviewed"
             },
             {
@@ -212,7 +212,7 @@
                 "mac": "cmd+7"
             },
             {
-                "command": "weAudit.addpartiallyAudited",
+                "command": "weAudit.addPartiallyAudited",
                 "key": "ctrl+shift+7",
                 "mac": "cmd+shift+7"
             },

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -610,7 +610,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             this.checkIfAllSiblingFilesAreAudited(uri);
         }
 
-        // clean out any partial audited file entries
+        // clean out any partially audited file entries
         this.cleanPartialAudits(uri);
 
         // update day log structure
@@ -1715,7 +1715,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
 
                 this.treeEntries = this.treeEntries.concat(parsedEntries.treeEntries);
                 this.auditedFiles = this.auditedFiles.concat(parsedEntries.auditedFiles);
-                // handle older versions of the extension that don't have partial audited entries
+                // handle older versions of the extension that don't have partially audited entries
                 this.partiallyAuditedFiles = this.partiallyAuditedFiles.concat(parsedEntries.partiallyAuditedFiles ?? []);
                 // handle older versions of the extension that don't have resolved entries
                 if (parsedEntries.resolvedEntries !== undefined) {

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1918,8 +1918,8 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         }
 
         // check if editor is partially audited, and mark locations as such
-        let partialAuditedRanges = this.partialAuditedFiles.filter((entry) => entry.path === fname);
-        let partialAuditedDecorations = partialAuditedRanges.map((r) => new vscode.Range(r.location.startLine, 0, r.location.endLine, 0));
+        const partialAuditedRanges = this.partialAuditedFiles.filter((entry) => entry.path === fname);
+        const partialAuditedDecorations = partialAuditedRanges.map((r) => new vscode.Range(r.location.startLine, 0, r.location.endLine, 0));
         editor.setDecorations(this.decorationManager.auditedFileDecorationType, [...range, ...partialAuditedDecorations]);
     }
 

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1588,7 +1588,10 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             if (previousEntries !== undefined) {
                 filteredEntries = mergeTwoEntryArrays(filteredEntries, previousEntries.treeEntries);
                 filteredAuditedFiles = mergeTwoAuditedFileArrays(filteredAuditedFiles, previousEntries.auditedFiles);
-                filteredPartiallyAuditedEntries = mergeTwoPartiallyAuditedFileArrays(filteredPartiallyAuditedEntries, previousEntries.partiallyAuditedFiles ?? []);
+                filteredPartiallyAuditedEntries = mergeTwoPartiallyAuditedFileArrays(
+                    filteredPartiallyAuditedEntries,
+                    previousEntries.partiallyAuditedFiles ?? [],
+                );
                 filteredResolvedEntries = mergeTwoEntryArrays(filteredResolvedEntries, previousEntries.resolvedEntries);
             }
         }
@@ -1933,7 +1936,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         // check if editor is partially audited, and mark locations as such
         const partiallyAuditedRanges = this.partiallyAuditedFiles.filter((entry) => entry.path === fname);
         const partiallyAuditedDecorations = partiallyAuditedRanges.map((r) => new vscode.Range(r.location.startLine, 0, r.location.endLine, 0));
-        editor.setDecorations(this.decorationManager.auditedFileDecorationType, [...range, ...partiallyAuditedDecorations]);
+        editor.setDecorations(this.decorationManager.auditedFileDecorationType, range.concat(partiallyAuditedDecorations));
     }
 
     /**

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1575,7 +1575,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             if (previousEntries !== undefined) {
                 filteredEntries = mergeTwoEntryArrays(filteredEntries, previousEntries.treeEntries);
                 filteredAuditedFiles = mergeTwoAuditedFileArrays(filteredAuditedFiles, previousEntries.auditedFiles);
-                filteredPartialAuditedEntries = mergeTwoPartialAuditedFileArrays(filteredPartialAuditedEntries, previousEntries.partialAuditedFiles);
+                filteredPartialAuditedEntries = mergeTwoPartialAuditedFileArrays(filteredPartialAuditedEntries, previousEntries.partialAuditedFiles ?? []);
                 filteredResolvedEntries = mergeTwoEntryArrays(filteredResolvedEntries, previousEntries.resolvedEntries);
             }
         }

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -641,19 +641,27 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         }
 
         const location = this.getActiveSelectionLocation();
+        const partialIndex = this.partialAuditedFiles.findIndex(
+            (file) => file.path === relativePath && file.location.startLine === location.startLine && file.location.endLine === location.endLine,
+        );
 
-        this.partialAuditedFiles.push({
-            path: relativePath,
-            author: this.username,
-            location: {
-                description: "Partially audited",
-                label: "Partial",
+        // this section is already marked. Remove it then
+        if (partialIndex > -1) {
+            this.partialAuditedFiles.splice(partialIndex, 1);
+        } else {
+            this.partialAuditedFiles.push({
                 path: relativePath,
-                startLine: location.startLine,
-                endLine: location.endLine,
-            },
-        });
-        this.mergePartialAudits();
+                author: this.username,
+                location: {
+                    description: "Partially audited",
+                    label: "Partial",
+                    path: relativePath,
+                    startLine: location.startLine,
+                    endLine: location.endLine,
+                },
+            });
+            this.mergePartialAudits();
+        }
 
         // update decorations
         this.decorateWithUri(uri);

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1691,7 +1691,8 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
 
                 this.treeEntries = this.treeEntries.concat(parsedEntries.treeEntries);
                 this.auditedFiles = this.auditedFiles.concat(parsedEntries.auditedFiles);
-                this.partialAuditedFiles = this.partialAuditedFiles.concat(parsedEntries.partialAuditedFiles);
+                // handle older versions of the extension that don't have partial audited entries
+                this.partialAuditedFiles = this.partialAuditedFiles.concat(parsedEntries.partialAuditedFiles ?? []);
                 // handle older versions of the extension that don't have resolved entries
                 if (parsedEntries.resolvedEntries !== undefined) {
                     this.resolvedEntries = this.resolvedEntries.concat(parsedEntries.resolvedEntries);

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -661,12 +661,12 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                 // if either the end line or the start line is the same we don't need
                 // to split the entry but can just adjust the current one
                 let splitNeeded = true;
-                if (previousMarkedEntry.endLine == location.endLine) {
+                if (previousMarkedEntry.endLine === location.endLine) {
                     previousMarkedEntry.endLine = location.startLine - 1;
                     splitNeeded = false;
                 }
 
-                if (previousMarkedEntry.startLine == location.startLine) {
+                if (previousMarkedEntry.startLine === location.startLine) {
                     previousMarkedEntry.startLine = location.endLine + 1;
                     splitNeeded = false;
                 }
@@ -2241,7 +2241,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         this.refresh(uri);
     }
 
-    private cleanPartialAudits(uriToRemove: vscode.Uri) {
+    private cleanPartialAudits(uriToRemove: vscode.Uri): void {
         const relative = path.relative(this.workspacePath, uriToRemove.fsPath);
         this.partiallyAuditedFiles = this.partiallyAuditedFiles.filter((file) => file.path !== relative);
     }

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -680,7 +680,6 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         // update decorations
         this.decorateWithUri(uri);
         this.updateSavedData(this.username);
-        this.refresh(uri);
     }
 
     /**

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -2230,13 +2230,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
 
     private cleanPartialAudits(uriToRemove: vscode.Uri) {
         const relative = path.relative(this.workspacePath, uriToRemove.fsPath);
-        const entries = this.partiallyAuditedFiles.filter((file) => file.path === relative);
-        for (const entry of entries) {
-            const index = this.partiallyAuditedFiles.indexOf(entry);
-            if (index > -1) {
-                this.partiallyAuditedFiles.splice(index, 1);
-            }
-        }
+        this.partiallyAuditedFiles = this.partiallyAuditedFiles.filter((file) => file.path !== relative);
     }
 
     private mergePartialAudits(): void {

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -2234,11 +2234,11 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                     // only merge entries for the same file
                     file.path === entry.path &&
                     // checks if the start is within bounds but the end is not
-                    ((file.location.startLine <= entry.location.startLine && file.location.endLine > entry.location.startLine) ||
+                    ((file.location.startLine <= entry.location.startLine && file.location.endLine >= entry.location.startLine) ||
                         // checks if the end is within bounds but the start is not
-                        (file.location.startLine <= entry.location.endLine && file.location.endLine > entry.location.endLine) ||
+                        (file.location.startLine <= entry.location.endLine && file.location.endLine >= entry.location.endLine) ||
                         // checks if the location includes the entry
-                        (file.location.startLine > entry.location.startLine && file.location.endLine < entry.location.endLine)),
+                        (file.location.startLine >= entry.location.startLine && file.location.endLine <= entry.location.endLine)),
             );
             // update entry if necessary
             if (partIdx > -1) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,8 +78,8 @@ export interface SerializedData {
     gitSha: string;
     treeEntries: Entry[];
     auditedFiles: AuditedFile[];
-    // older versions do not have partialAuditedFiles
-    partialAuditedFiles?: PartialAuditedFile[];
+    // older versions do not have partiallyAuditedFiles
+    partiallyAuditedFiles?: PartiallyAuditedFile[];
     resolvedEntries: Entry[];
 }
 
@@ -93,7 +93,7 @@ export function createDefaultSerializedData(): SerializedData {
         gitSha: "",
         treeEntries: [],
         auditedFiles: [],
-        partialAuditedFiles: [],
+        partiallyAuditedFiles: [],
         resolvedEntries: [],
     };
 }
@@ -113,9 +113,9 @@ export function validateSerializedData(data: SerializedData): boolean {
             return false;
         }
     }
-    if (data.partialAuditedFiles) {
-        for (const partialAuditedFile of data.partialAuditedFiles) {
-            if (!validatePartialAuditedFile(partialAuditedFile)) {
+    if (data.partiallyAuditedFiles) {
+        for (const partiallyAuditedFile of data.partiallyAuditedFiles) {
+            if (!validatepartiallyAuditedFile(partiallyAuditedFile)) {
                 return false;
             }
         }
@@ -153,8 +153,8 @@ function validateAuditedFile(auditedFile: AuditedFile): boolean {
     return auditedFile.path !== undefined && auditedFile.author !== undefined;
 }
 
-function validatePartialAuditedFile(partialAuditedFile: PartialAuditedFile): boolean {
-    return validateAuditedFile(partialAuditedFile) || validateLocation(partialAuditedFile.location);
+function validatepartiallyAuditedFile(partiallyAuditedFile: PartiallyAuditedFile): boolean {
+    return validateAuditedFile(partiallyAuditedFile) || validateLocation(partiallyAuditedFile.location);
 }
 
 function validateLocation(location: Location): boolean {
@@ -352,7 +352,7 @@ function auditedEquals(a: AuditedFile, b: AuditedFile): boolean {
  * @param b the second audited file
  * @returns true if the audited files are equal, false otherwise
  */
-function partialAuditedEquals(a: PartialAuditedFile, b: PartialAuditedFile): boolean {
+function partiallyAuditedEquals(a: PartiallyAuditedFile, b: PartiallyAuditedFile): boolean {
     return a.path === b.path && a.location.startLine === b.location.startLine && a.location.endLine === b.location.endLine;
 }
 
@@ -387,14 +387,14 @@ export function mergeTwoAuditedFileArrays(a: AuditedFile[], b: AuditedFile[]): A
  * @param b the second array
  * @returns the merged array
  */
-export function mergeTwoPartialAuditedFileArrays(a: PartialAuditedFile[], b: PartialAuditedFile[]): PartialAuditedFile[] {
+export function mergeTwoPartiallyAuditedFileArrays(a: PartiallyAuditedFile[], b: PartiallyAuditedFile[]): PartiallyAuditedFile[] {
     // merge two arrays of entries
     // without duplicates
-    const result: PartialAuditedFile[] = a;
+    const result: PartiallyAuditedFile[] = a;
     for (let i = 0; i < b.length; i++) {
         let found = false;
         for (let j = 0; j < a.length; j++) {
-            if (partialAuditedEquals(a[j], b[i])) {
+            if (partiallyAuditedEquals(a[j], b[i])) {
                 found = true;
                 break;
             }
@@ -411,7 +411,7 @@ export interface AuditedFile {
     author: string;
 }
 
-export interface PartialAuditedFile {
+export interface PartiallyAuditedFile {
     path: string;
     author: string;
     location: Location;

--- a/src/types.ts
+++ b/src/types.ts
@@ -347,7 +347,7 @@ function auditedEquals(a: AuditedFile, b: AuditedFile): boolean {
 }
 
 /**
- * Checks if two partial audited files are equal.
+ * Checks if two partially audited files are equal.
  * @param a the first audited file
  * @param b the second audited file
  * @returns true if the audited files are equal, false otherwise
@@ -382,7 +382,7 @@ export function mergeTwoAuditedFileArrays(a: AuditedFile[], b: AuditedFile[]): A
 }
 
 /**
- * Merges two arrays of partial audited files, removing duplicates.
+ * Merges two arrays of partially audited files, removing duplicates.
  * @param a the first array
  * @param b the second array
  * @returns the merged array

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,7 +154,7 @@ function validateAuditedFile(auditedFile: AuditedFile): boolean {
 }
 
 function validatepartiallyAuditedFile(partiallyAuditedFile: PartiallyAuditedFile): boolean {
-    return validateAuditedFile(partiallyAuditedFile) || validateLocation(partiallyAuditedFile.location);
+    return validateAuditedFile(partiallyAuditedFile) || partiallyAuditedFile.startLine !== undefined || partiallyAuditedFile.endLine !== undefined;
 }
 
 function validateLocation(location: Location): boolean {
@@ -414,7 +414,8 @@ export interface AuditedFile {
 export interface PartiallyAuditedFile {
     path: string;
     author: string;
-    location: Location;
+    startLine: number;
+    endLine: number;
 }
 
 export enum TreeViewMode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,8 @@ export interface SerializedData {
     gitSha: string;
     treeEntries: Entry[];
     auditedFiles: AuditedFile[];
-    partialAuditedFiles: PartialAuditedFile[];
+    // older versions do not have partialAuditedFiles
+    partialAuditedFiles?: PartialAuditedFile[];
     resolvedEntries: Entry[];
 }
 
@@ -112,9 +113,11 @@ export function validateSerializedData(data: SerializedData): boolean {
             return false;
         }
     }
-    for (const partialAuditedFile of data.partialAuditedFiles) {
-        if (!validatePartialAuditedFile(partialAuditedFile)) {
-            return false;
+    if (data.partialAuditedFiles) {
+        for (const partialAuditedFile of data.partialAuditedFiles) {
+            if (!validatePartialAuditedFile(partialAuditedFile)) {
+                return false;
+            }
         }
     }
     return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -353,7 +353,7 @@ function auditedEquals(a: AuditedFile, b: AuditedFile): boolean {
  * @returns true if the audited files are equal, false otherwise
  */
 function partiallyAuditedEquals(a: PartiallyAuditedFile, b: PartiallyAuditedFile): boolean {
-    return a.path === b.path && a.location.startLine === b.location.startLine && a.location.endLine === b.location.endLine;
+    return a.path === b.path && a.startLine === b.startLine && a.endLine === b.endLine;
 }
 
 /**


### PR DESCRIPTION
This pull adds the functionality to mark a region as reviewed.
It merges overlapping regions, ignores regions that are already marked by one that is bigger, and removes the entry if the exact region is selected.

It doesn't update the daily log. Maybe a feature could be added so that you get an exact line count for the daily log but this would break existing logs.

The new shortcut defined isn't set in stone but made sense to me. Idk if this combination actually works for macOS.

Resolves: Issue #20 (had the same pain in the past days)