### PR TITLE
ci: add publishing action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Build release and publish on VSCode's Marketplace and OpenVSX
+on:
+    release:
+        types: [published]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build the vsix
+              run: npx vsce package -o weaudit.vsix
+
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: "weaudit"
+                  path: "weaudit.vsix"
+
+    publish:
+        runs-on: ubuntu-latest
+        needs: build
+        if: success()
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: "weaudit"
+
+            # Uncomment the following lines to also publish the extension on the VSCode Marketplace
+            # - name: Publish Extension on VSCode's Marketplace
+            #   run: npx vsce publish --pat ${{ secrets.VSCODE_PUBLISHING_TOKEN }} --packagePath weaudit.vsix
+
+            - name: Publish Extension on OpenVSX
+              run: npx ovsx publish --pat ${{ secrets.WEAUDIT_OPENVSX_TOKEN }} --packagePath weaudit.vsix
+
+            - name: Add vsix to the release assets
+              uses: actions/upload-release-asset@v1.0.2
+              with:
+                  upload_url: ${{ github.event.release.upload_url }}
+                  asset_path: weaudit.vsix
+                  asset_name: weaudit.vsix
+                  asset_content_type: application/octet-stream
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a publishing action that:

1. builds the vsix from the source code
2. uploads the vsix to open-vsx marketplace
3. uploads the vsix to the github release assets

Uploading to vscode's marketplace is currently commented out until we generate the personal access token for that.