### PR TITLE
add configurable toggle for marking whole directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ After reviewing a file, you can mark it as audited by calling the `weAudit: Mark
 
 ![Mark File as Reviewed](media/readme/gifs/mark_audited.gif)
 
+Alternatively, you can right click the file in the Explorer view and select `weAudit: Mark as Reviewed`
+
 The highlighted color can be customized in the [settings](#settings).
 
 ### Partially Audited Files

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
             },
             {
                 "command": "weAudit.toggleAuditedUri",
-                "title": "weAudit: Mark as Reviewed by URI"
+                "title": "weAudit: Mark as Reviewed"
             },
             {
                 "command": "weAudit.addPartiallyAudited",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,10 @@
                 "title": "weAudit: Mark File as Reviewed"
             },
             {
+                "command": "weAudit.toggleAuditedUri",
+                "title": "weAudit: Mark as Reviewed by URI"
+            },
+            {
                 "command": "weAudit.addPartiallyAudited",
                 "title": "weAudit: Mark Region as Reviewed"
             },
@@ -391,6 +395,12 @@
                     "command": "weAudit.copySelectedCodeClientPermalink",
                     "group": "9_cutcopypaste@0"
                 }
+            ],
+            "explorer/context": [
+                {
+                    "command": "weAudit.toggleAuditedUri",
+                    "group": "1_modification"
+                }
             ]
         },
         "configuration": [
@@ -420,6 +430,21 @@
                         "type": "string",
                         "default": "",
                         "description": "The username to use as the finding's author. (Defaults to the system's username if left empty.)"
+                    },
+                    "weAudit.general.recursionBehavior": {
+                        "type": "string",
+                        "default": "full",
+                        "enum": [
+                            "none",
+                            "direct",
+                            "full"
+                        ],
+                        "enumDescriptions": [
+                            "Do not recurse, toggle directory only",
+                            "Recurse to direct children only, no subdirectories",
+                            "Fully recurse to all children and subdirectories"
+                        ],
+                        "description": "Recursion style when marking directory as audited."
                     }
                 }
             },


### PR DESCRIPTION
Hello again :wave: :blush: 

This is a small PR implementing #30 , the ability to mark entire folders/directories as reviewed.

The `toggleAuditedUri` function will use the `vscode.fs` API to check if the URI in question is a directory or file, making a separate function for directories unnecessary.
This also makes adding a context menu action for the command simpler :slightly_smiling_face: 

For the behavior when encountering a directory, I added a configuration option with three modes:
- no recursion: mark the directory only
- direct children only: mark the directory and child files, no subdirectories
- full recursion: recurse into all subdirectories, toggling all files

All the best :blush: 