### PR TITLE
Add button to copy all audit permalinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
                 "icon": "$(link)"
             },
             {
+                "command": "weAudit.copyEntryPermalinks",
+                "title": "Copy All Audit Permalinks",
+                "icon": "$(link)"
+            },
+            {
                 "command": "weAudit.copySelectedCodePermalink",
                 "title": "weAudit: Copy Permalink (Audit Repository)"
             },
@@ -369,7 +374,12 @@
                 },
                 {
                     "command": "weAudit.copyEntryPermalink",
-                    "when": "view == codeMarker && viewItem != pathOrganizer",
+                    "when": "view == codeMarker && viewItem == additionalLocation",
+                    "group": "inline@2"
+                },
+                {
+                    "command": "weAudit.copyEntryPermalinks",
+                    "when": "view == codeMarker && viewItem != pathOrganizer && viewItem != additionalLocation",
                     "group": "inline@2"
                 },
                 {
@@ -450,6 +460,11 @@
                         "type": "string",
                         "default": "",
                         "description": "The username to use as the finding's author. (Defaults to the system's username if left empty.)"
+                    },
+                    "weAudit.general.permalinkSeparator": {
+                        "type": "string",
+                        "default": "\\n",
+                        "description": "The separator to use in permalinks. (Note that \\n is interpreted as a newline)"
                     }
                 }
             },
@@ -491,7 +506,8 @@
         "compile": "node ./esbuild.js",
         "package": "NODE_ENV=production node ./esbuild.js",
         "watch": "node ./esbuild.js --watch",
-        "lint": "eslint src --ext ts"
+        "lint": "eslint src --ext ts",
+        "prettier": "prettier --write ."
     },
     "devDependencies": {
         "@microsoft/eslint-formatter-sarif": "^3.0.0",

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1771,6 +1771,10 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             this.copyEntryPermalink(entry);
         });
 
+        vscode.commands.registerCommand("weAudit.copyEntryPermalinks", (entry: FullEntry) => {
+            this.copyEntryPermalinks(entry);
+        });
+
         vscode.commands.registerTextEditorCommand("weAudit.copySelectedCodePermalink", () => {
             this.copySelectedCodePermalink(Repository.Audit);
         });
@@ -2556,6 +2560,30 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             return;
         }
         this.copyToClipboard(remoteAndPermalink.permalink);
+    }
+
+    /**
+     * Copy all permalinks of the given entry to the clipboard
+     * @param entry The entry to copy the permalinks of
+     */
+    async copyEntryPermalinks(entry: FullEntry): Promise<void> {
+        const permalinkList = [];
+        for (const location of entry.locations) {
+            const remoteAndPermalink = await this.getEntryRemoteAndPermalink(location);
+            if (remoteAndPermalink === undefined) {
+                return;
+            }
+            permalinkList.push(remoteAndPermalink.permalink);
+        }
+
+        // get separator from configuration
+        const separator: string = vscode.workspace.getConfiguration("weAudit").get("general.permalinkSeparator") || "\n";
+        // interpret \n as newline
+        const interpretedSep = separator.replace(/\\n/g, "\n");
+        // join the permalinks with the separator
+        const permalinksString = permalinkList.join(interpretedSep);
+        // copy the permalinks to the clipboard
+        this.copyToClipboard(permalinksString);
     }
 
     /**


### PR DESCRIPTION
Fixes #62.

Besides adding the button that will copy all permalinks, there is a configuration on the extension settings to define the separator to join the links, which defaults to "\n"