### PR TITLE
fix: `watch` is broken on current esbuild

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -41,7 +41,9 @@ const watchPlugin = {
         });
 
         build.onEnd((result) => {
-            console.log(`${result.errors.length > 0 ? "[watch] build finished with errors" : "[watch] build finished successfully"} (${build.initialOptions.outfile})`);
+            console.log(
+                `${result.errors.length > 0 ? "[watch] build finished with errors" : "[watch] build finished successfully"} (${build.initialOptions.outfile})`,
+            );
         });
     },
 };


### PR DESCRIPTION
Restores the functionality of the watch command lost to breaking API changes in esbuild:

| Before | After |
| - | - |
| <img width="582" height="162" alt="image" src="https://github.com/user-attachments/assets/c8eb3160-dd95-4e5c-99e1-14e878a90c9e" /> | <img width="505" height="301" alt="image" src="https://github.com/user-attachments/assets/3a0b6555-c5c3-4ac6-93cd-12df088d148c" /> |

