### PR TITLE
feat: Add region boundary editing feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ out
 dist
 node_modules
 .vscode-test/
-.vscode/
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 *.mov
 *.vsix
 *.sarif*

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,13 @@
 import { defineConfig } from "@vscode/test-cli";
 import * as path from "path";
+import * as fs from "fs";
+
+const sharedStorageDir = path.resolve(".test-extensions");
+const userDataDir = path.join(sharedStorageDir, "user-data");
+const extensionsDir = path.join(sharedStorageDir, "extensions");
+
+fs.mkdirSync(userDataDir, { recursive: true });
+fs.mkdirSync(extensionsDir, { recursive: true });
 
 export default defineConfig({
     files: "out/test/extension/suite/**/*.test.js",
@@ -9,6 +17,6 @@ export default defineConfig({
         ui: "tdd",
         timeout: 60000,
     },
-    launchArgs: ["--disable-extensions", "--disable-gpu", "--disable-workspace-trust"],
+    launchArgs: ["--disable-extensions", "--disable-gpu", "--disable-workspace-trust", "--user-data-dir", userDataDir, "--extensions-dir", extensionsDir],
     extensionDevelopmentPath: path.resolve("."),
 });

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "name": "Launch Extension",
+            "outFiles": ["${workspaceFolder}/out/**/*.js", "--extensionDevelopmentPath=${workspaceFolder}"],
+            "preLaunchTask": "${defaultBuildTask}",
+            "request": "launch",
+            "type": "extensionHost",
+            "sourceMaps": true
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "watch",
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": [],
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build"
+            }
+        },
+        {
+            "label": "compile",
+            "type": "npm",
+            "script": "compile",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can add multiple regions to a single finding or note. Once you select the co
 
 Need to tweak the highlighted range for an existing finding? Run the `weAudit: Edit Finding Boundary` command to enter boundary editing mode. weAudit shows a set of inline CodeLens controls at the top and bottom of the region so you can expand, shrink, or move the selection and click `Done` when you are satisfied.
 
-Once in boundary editing mode you can also use the dedicated keyboard shortcuts to make quick adjustments without touching the mouse. These shortcuts automatically focus the relevant finding, so you can adjust boundaries from the keyboard only.
+You can also use the dedicated keyboard shortcuts to make quick adjustments without touching the mouse. These shortcuts automatically focus the relevant finding, so you can adjust boundaries from the keyboard only.
 
 ### Resolve and Restore
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ You can configure the keybindings to any of the extension's commands in the VSCo
 -   `weAudit.boundaryExpandDown`: Expand Finding Down: `cmd + shift + numpad1`
 -   `weAudit.boundaryMoveDown`: Move Finding Down: `cmd + shift + numpad2`
 -   `weAudit.boundaryShrinkBottom`: Shrink Finding from Bottom: `cmd + shift + numpad3`
--   `weAudit.stopEditingBoundary`: Finish Boundary Editing: `cmd + shift + numpad5`
+-   `weAudit.editFindingBoundary`: Start Boundary Editing (when not editing): `cmd + shift + numpad5`
+-   `weAudit.stopEditingBoundary`: Finish Boundary Editing (when editing): `cmd + shift + numpad5`
 
 ## WeAudit Concepts
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ You can add multiple regions to a single finding or note. Once you select the co
 
 ![Add Region to a Finding](media/readme/gifs/multi_region_finding.gif)
 
+### Boundary Editing
+
+Need to tweak the highlighted range for an existing finding? Run the `weAudit: Edit Finding Boundary` command to enter boundary editing mode. weAudit shows a set of inline CodeLens controls at the top and bottom of the region so you can expand, shrink, or move the selection and click `Done` when you are satisfied.
+
+Once in boundary editing mode you can also use the dedicated keyboard shortcuts to make quick adjustments without touching the mouse. These shortcuts automatically focus the relevant finding, so you can adjust boundaries from the keyboard only.
+
 ### Resolve and Restore
 
 You can resolve a finding by clicking on the corresponding `Resolve` button in the _List of Findings_ panel. The finding will no longer be highlighted in the editor, but will still be visible in the _Resolved Findings_ panel. You can restore a resolved finding by clicking on the corresponding `Restore` button in the _Resolved Findings_ panel.
@@ -201,6 +207,13 @@ You can configure the keybindings to any of the extension's commands in the VSCo
 -   `weAudit.copySelectedCodePermalink`: Copy Permalink (for the Selected Code Region): `cmd + 8`
 -   `weAudit.copySelectedCodeClientPermalink`: Copy Client Permalink (for the Selected Code Region): `cmd + 9`
 -   `weAudit.navigateToNextPartiallyAuditedRegion`: Navigate to Next Partially Audited Region: `cmd + 0`
+-   `weAudit.boundaryExpandUp`: Expand Finding Up: `cmd + shift + numpad7`
+-   `weAudit.boundaryMoveUp`: Move Finding Up: `cmd + shift + numpad8`
+-   `weAudit.boundaryShrinkTop`: Shrink Finding from Top: `cmd + shift + numpad9`
+-   `weAudit.boundaryExpandDown`: Expand Finding Down: `cmd + shift + numpad1`
+-   `weAudit.boundaryMoveDown`: Move Finding Down: `cmd + shift + numpad2`
+-   `weAudit.boundaryShrinkBottom`: Shrink Finding from Bottom: `cmd + shift + numpad3`
+-   `weAudit.stopEditingBoundary`: Finish Boundary Editing: `cmd + shift + numpad5`
 
 ## WeAudit Concepts
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -51,6 +51,10 @@ npm run test:ui
 npm run test:ui-setup
 ```
 
+### Shared Test VS Code Profile
+
+Both `npm run test:ext` and `npm run test:ui` run VS Code with isolated user data and extensions directories under `.test-extensions/` so local/user-installed extensions do not affect test results.
+
 ### Example UI Test
 
 ```typescript

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,6 @@
         "enabled": false
     },
     "files": {
-        "includes": ["src/**", "test/**", "*.ts", "*.js", "*.json", "*.cjs", "*.mjs"]
+        "includes": ["src/**", "test/**", ".vscode/**", "*.ts", "*.js", "*.json", "*.cjs", "*.mjs"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
                 "mac": "cmd+shift+numpad5",
                 "when": "weAudit.boundaryEditing && editorTextFocus"
             },
-                        {
+            {
                 "command": "weAudit.editFindingBoundary",
                 "key": "ctrl+shift+numpad5",
                 "mac": "cmd+shift+numpad5",

--- a/package.json
+++ b/package.json
@@ -324,37 +324,49 @@
                 "command": "weAudit.boundaryExpandUp",
                 "key": "ctrl+shift+numpad7",
                 "mac": "cmd+shift+numpad7",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
             },
             {
                 "command": "weAudit.boundaryMoveUp",
                 "key": "ctrl+shift+numpad8",
                 "mac": "cmd+shift+numpad8",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
             },
             {
                 "command": "weAudit.boundaryShrinkTop",
                 "key": "ctrl+shift+numpad9",
                 "mac": "cmd+shift+numpad9",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
             },
             {
                 "command": "weAudit.boundaryExpandDown",
                 "key": "ctrl+shift+numpad1",
                 "mac": "cmd+shift+numpad1",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
             },
             {
                 "command": "weAudit.boundaryMoveDown",
                 "key": "ctrl+shift+numpad2",
                 "mac": "cmd+shift+numpad2",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
             },
             {
                 "command": "weAudit.boundaryShrinkBottom",
                 "key": "ctrl+shift+numpad3",
                 "mac": "cmd+shift+numpad3",
-                "when": "weAudit.boundaryEditing"
+                "when": "editorTextFocus"
+            },
+            {
+                "command": "weAudit.stopEditingBoundary",
+                "key": "ctrl+shift+numpad5",
+                "mac": "cmd+shift+numpad5",
+                "when": "weAudit.boundaryEditing && editorTextFocus"
+            },
+                        {
+                "command": "weAudit.editFindingBoundary",
+                "key": "ctrl+shift+numpad5",
+                "mac": "cmd+shift+numpad5",
+                "when": "!weAudit.boundaryEditing && editorTextFocus"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -240,6 +240,38 @@
             {
                 "command": "weAudit.toggleFindingsHighlighting",
                 "title": "weAudit: Toggle Findings Highlighting"
+            },
+            {
+                "command": "weAudit.editFindingBoundary",
+                "title": "weAudit: Edit Finding Boundary"
+            },
+            {
+                "command": "weAudit.stopEditingBoundary",
+                "title": "weAudit: Stop Editing Finding Boundary"
+            },
+            {
+                "command": "weAudit.boundaryExpandUp",
+                "title": "weAudit: Expand Finding Boundary Up"
+            },
+            {
+                "command": "weAudit.boundaryShrinkTop",
+                "title": "weAudit: Shrink Finding Boundary from Top"
+            },
+            {
+                "command": "weAudit.boundaryExpandDown",
+                "title": "weAudit: Expand Finding Boundary Down"
+            },
+            {
+                "command": "weAudit.boundaryShrinkBottom",
+                "title": "weAudit: Shrink Finding Boundary from Bottom"
+            },
+            {
+                "command": "weAudit.boundaryMoveUp",
+                "title": "weAudit: Move Finding Up"
+            },
+            {
+                "command": "weAudit.boundaryMoveDown",
+                "title": "weAudit: Move Finding Down"
             }
         ],
         "keybindings": [
@@ -287,6 +319,42 @@
                 "command": "weAudit.navigateToNextPartiallyAuditedRegion",
                 "key": "ctrl+alt+0",
                 "mac": "cmd+0"
+            },
+            {
+                "command": "weAudit.boundaryExpandUp",
+                "key": "ctrl+shift+numpad7",
+                "mac": "cmd+shift+numpad7",
+                "when": "weAudit.boundaryEditing"
+            },
+            {
+                "command": "weAudit.boundaryMoveUp",
+                "key": "ctrl+shift+numpad8",
+                "mac": "cmd+shift+numpad8",
+                "when": "weAudit.boundaryEditing"
+            },
+            {
+                "command": "weAudit.boundaryShrinkTop",
+                "key": "ctrl+shift+numpad9",
+                "mac": "cmd+shift+numpad9",
+                "when": "weAudit.boundaryEditing"
+            },
+            {
+                "command": "weAudit.boundaryExpandDown",
+                "key": "ctrl+shift+numpad1",
+                "mac": "cmd+shift+numpad1",
+                "when": "weAudit.boundaryEditing"
+            },
+            {
+                "command": "weAudit.boundaryMoveDown",
+                "key": "ctrl+shift+numpad2",
+                "mac": "cmd+shift+numpad2",
+                "when": "weAudit.boundaryEditing"
+            },
+            {
+                "command": "weAudit.boundaryShrinkBottom",
+                "key": "ctrl+shift+numpad3",
+                "mac": "cmd+shift+numpad3",
+                "when": "weAudit.boundaryEditing"
             }
         ],
         "menus": {
@@ -333,6 +401,30 @@
                 },
                 {
                     "command": "weAudit.deleteAllResolvedFinding",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryExpandUp",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryShrinkTop",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryExpandDown",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryShrinkBottom",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryMoveUp",
+                    "when": "false"
+                },
+                {
+                    "command": "weAudit.boundaryMoveDown",
                     "when": "false"
                 }
             ],

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -4496,8 +4496,8 @@ export class AuditMarker {
             try {
                 await treeView.reveal(entry);
             } catch (error) {
-                const typedError = error as Error;
-                if (typedError.message.startsWith("TreeError")) {
+                const message = (error as Error).message ?? "";
+                if (message.startsWith("TreeError") || message.includes("Cannot resolve tree item")) {
                     return;
                 }
                 throw error;

--- a/src/findingBoundaryCodeLens.ts
+++ b/src/findingBoundaryCodeLens.ts
@@ -15,6 +15,7 @@ interface BoundaryEditSession {
 }
 
 const BOUNDARY_COMMANDS = {
+    /* eslint-disable @typescript-eslint/naming-convention */
     "weAudit.boundaryExpandUp": {
         title: "$(arrow-up) Expand",
         tooltip: "Expand finding boundary up by one line",
@@ -43,6 +44,7 @@ const BOUNDARY_COMMANDS = {
         title: "$(check) Done",
         tooltip: "Finish editing finding boundary",
     },
+    /* eslint-enable @typescript-eslint/naming-convention */
 } as const;
 
 type BoundaryCommandId = keyof typeof BOUNDARY_COMMANDS;
@@ -351,9 +353,7 @@ export function activateFindingBoundaryCodeLens(
      * @param locationOrEntry the entry or specific location entry under the cursor
      * @returns the concrete entry and the index of the location being edited
      */
-    const resolveEntrySelection = (
-        locationOrEntry: FullEntry | FullLocationEntry | undefined,
-    ): { entry: FullEntry; locationIndex: number } | undefined => {
+    const resolveEntrySelection = (locationOrEntry: FullEntry | FullLocationEntry | undefined): { entry: FullEntry; locationIndex: number } | undefined => {
         if (!locationOrEntry) {
             return undefined;
         }

--- a/src/findingBoundaryCodeLens.ts
+++ b/src/findingBoundaryCodeLens.ts
@@ -1,0 +1,447 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { FullEntry, FullLocation, FullLocationEntry, isEntry, isLocationEntry } from "./types";
+
+/**
+ * Represents an active boundary editing session for a specific location within a finding.
+ */
+interface BoundaryEditSession {
+    /** The entry being edited */
+    entry: FullEntry;
+    /** Index of the location within entry.locations being edited */
+    locationIndex: number;
+    /** The file URI where editing is happening */
+    uri: vscode.Uri;
+}
+
+/**
+ * CodeLens provider that displays boundary adjustment controls for findings.
+ * This provider is only active when a user explicitly enters boundary editing mode
+ * via the "weAudit.editFindingBoundary" command. Controls appear at the start and
+ * end lines of the finding, allowing users to expand or shrink the highlighted region.
+ */
+export class FindingBoundaryCodeLensProvider implements vscode.CodeLensProvider {
+    private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
+
+    /** Currently active editing session, or undefined if not editing */
+    private activeSession: BoundaryEditSession | undefined;
+
+    /** Common decoration properties for all boundary styles */
+    private readonly commonDecorationProps = {
+        isWholeLine: true,
+        borderStyle: "solid" as const,
+        light: { borderColor: "#f0ad4e" },
+        dark: { borderColor: "#ffcf70" },
+    };
+
+    private readonly decorationStyles = {
+        single: vscode.window.createTextEditorDecorationType({
+            ...this.commonDecorationProps,
+            borderWidth: "2px",
+        }),
+        top: vscode.window.createTextEditorDecorationType({
+            ...this.commonDecorationProps,
+            borderWidth: "2px 2px 0px 2px",
+        }),
+        middle: vscode.window.createTextEditorDecorationType({
+            ...this.commonDecorationProps,
+            borderWidth: "0px 2px 0px 2px",
+        }),
+        bottom: vscode.window.createTextEditorDecorationType({
+            ...this.commonDecorationProps,
+            borderWidth: "0px 2px 2px 2px",
+        }),
+    };
+
+    constructor() {
+        void vscode.commands.executeCommand("setContext", "weAudit.boundaryEditing", false);
+    }
+
+    /**
+     * Checks if boundary editing mode is currently active.
+     * @returns true if a boundary editing session is in progress
+     */
+    isEditing(): boolean {
+        return this.activeSession !== undefined;
+    }
+
+    /**
+     * Gets the currently active editing session.
+     * @returns the active session or undefined
+     */
+    getActiveSession(): BoundaryEditSession | undefined {
+        return this.activeSession;
+    }
+
+    /**
+     * Starts boundary editing mode for a specific entry and location.
+     * @param entry the finding/note entry to edit
+     * @param locationIndex the index of the location within the entry to edit
+     */
+    startEditing(entry: FullEntry, locationIndex: number): void {
+        if (locationIndex < 0 || locationIndex >= entry.locations.length) {
+            return;
+        }
+
+        const location = entry.locations[locationIndex];
+        const filePath = path.join(location.rootPath, location.path);
+        this.activeSession = {
+            entry,
+            locationIndex,
+            uri: vscode.Uri.file(filePath),
+        };
+
+        vscode.commands.executeCommand("setContext", "weAudit.boundaryEditing", true);
+
+        // Force refresh of CodeLenses in all visible editors
+        this._onDidChangeCodeLenses.fire();
+        this.refreshEditingDecorations();
+
+        // Also focus the editor on the finding location to ensure it's visible
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.uri.fsPath === filePath) {
+            const range = new vscode.Range(location.startLine, 0, location.endLine, 0);
+            editor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+        }
+    }
+
+    /**
+     * Stops boundary editing mode and clears the active session.
+     */
+    stopEditing(): void {
+        this.activeSession = undefined;
+        void vscode.commands.executeCommand("setContext", "weAudit.boundaryEditing", false);
+        this._onDidChangeCodeLenses.fire();
+        this.refreshEditingDecorations();
+    }
+
+    /**
+     * Updates the active session's entry reference (called after boundary modifications).
+     * @param entry the updated entry
+     */
+    updateEntry(entry: FullEntry): void {
+        if (this.activeSession) {
+            this.activeSession.entry = entry;
+            this._onDidChangeCodeLenses.fire();
+            this.refreshEditingDecorations();
+        }
+    }
+
+    public updateDecorationsForVisibleEditors(): void {
+        this.refreshEditingDecorations();
+    }
+    private refreshEditingDecorations(): void {
+        for (const editor of vscode.window.visibleTextEditors) {
+            if (!this.activeSession || !this.isSessionDocument(editor.document.uri)) {
+                this.clearDecorations(editor);
+                continue;
+            }
+
+            const location = this.activeSession.entry.locations[this.activeSession.locationIndex];
+            if (!location) {
+                this.clearDecorations(editor);
+                continue;
+            }
+
+            const decorations = this.buildDecorationRanges(location);
+            editor.setDecorations(this.decorationStyles.single, decorations.single);
+            editor.setDecorations(this.decorationStyles.top, decorations.top);
+            editor.setDecorations(this.decorationStyles.middle, decorations.middle);
+            editor.setDecorations(this.decorationStyles.bottom, decorations.bottom);
+        }
+    }
+
+    private buildDecorationRanges(location: FullLocation): Record<"single" | "top" | "middle" | "bottom", vscode.Range[]> {
+        const ranges = {
+            single: [] as vscode.Range[],
+            top: [] as vscode.Range[],
+            middle: [] as vscode.Range[],
+            bottom: [] as vscode.Range[],
+        };
+
+        if (location.startLine === location.endLine) {
+            ranges.single.push(new vscode.Range(location.startLine, 0, location.startLine, 0));
+            return ranges;
+        }
+
+        ranges.top.push(new vscode.Range(location.startLine, 0, location.startLine, 0));
+        for (let line = location.startLine + 1; line < location.endLine; line++) {
+            ranges.middle.push(new vscode.Range(line, 0, line, 0));
+        }
+        ranges.bottom.push(new vscode.Range(location.endLine, 0, location.endLine, 0));
+
+        return ranges;
+    }
+
+    private clearDecorations(editor: vscode.TextEditor): void {
+        editor.setDecorations(this.decorationStyles.single, []);
+        editor.setDecorations(this.decorationStyles.top, []);
+        editor.setDecorations(this.decorationStyles.middle, []);
+        editor.setDecorations(this.decorationStyles.bottom, []);
+    }
+
+    private isSessionDocument(uri: vscode.Uri): boolean {
+        if (!this.activeSession) {
+            return false;
+        }
+        return path.normalize(uri.fsPath) === path.normalize(this.activeSession.uri.fsPath);
+    }
+
+    /**
+     * Provides CodeLens items for the document.
+     * Only returns lenses when boundary editing mode is active and the document matches.
+     */
+    provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.CodeLens[] {
+        if (!this.activeSession) {
+            return [];
+        }
+
+        // Compare paths - normalize both to handle any path format differences
+        const docPath = document.uri.fsPath;
+        const sessionPath = this.activeSession.uri.fsPath;
+
+        // Only show lenses for the file being edited
+        if (path.normalize(docPath) !== path.normalize(sessionPath)) {
+            return [];
+        }
+
+        const location = this.activeSession.entry.locations[this.activeSession.locationIndex];
+        if (!location) {
+            return [];
+        }
+        const lenses: vscode.CodeLens[] = [];
+
+        // Create a unique identifier for the location
+        const locationId = `${this.activeSession.entry.label}:${this.activeSession.locationIndex}`;
+
+        // === TOP BOUNDARY CONTROLS (at startLine) ===
+        const topRange = new vscode.Range(location.startLine, 0, location.startLine, 0);
+
+        // Expand up (move startLine up by 1)
+        if (location.startLine > 0) {
+            lenses.push(
+                new vscode.CodeLens(topRange, {
+                    title: "$(arrow-up) Expand",
+                    command: "weAudit.boundaryExpandUp",
+                    tooltip: "Expand finding boundary up by one line",
+                    arguments: [locationId],
+                }),
+            );
+        }
+
+        // Shrink from top (move startLine down by 1)
+        if (location.startLine < location.endLine) {
+            lenses.push(
+                new vscode.CodeLens(topRange, {
+                    title: "$(arrow-down) Shrink",
+                    command: "weAudit.boundaryShrinkTop",
+                    tooltip: "Shrink finding boundary from top by one line",
+                    arguments: [locationId],
+                }),
+            );
+        }
+
+        // Move up (shift entire region up by 1)
+        if (location.startLine > 0) {
+            lenses.push(
+                new vscode.CodeLens(topRange, {
+                    title: "$(triangle-up) Move",
+                    command: "weAudit.boundaryMoveUp",
+                    tooltip: "Move entire finding up by one line",
+                    arguments: [locationId],
+                }),
+            );
+        }
+
+        // Done button at the top
+        lenses.push(
+            new vscode.CodeLens(topRange, {
+                title: "$(check) Done",
+                command: "weAudit.stopEditingBoundary",
+                tooltip: "Finish editing finding boundary",
+                arguments: [],
+            }),
+        );
+
+        // === BOTTOM BOUNDARY CONTROLS (at endLine) ===
+        // Only show bottom controls if endLine is different from startLine
+        if (location.endLine !== location.startLine) {
+            const bottomLine = Math.min(location.endLine + 1, document.lineCount - 1);
+            const bottomRange = new vscode.Range(bottomLine, 0, bottomLine, 0);
+
+            // Shrink from bottom (move endLine up by 1)
+            if (location.endLine > location.startLine) {
+                lenses.push(
+                    new vscode.CodeLens(bottomRange, {
+                        title: "$(arrow-up) Shrink",
+                        command: "weAudit.boundaryShrinkBottom",
+                        tooltip: "Shrink finding boundary from bottom by one line",
+                        arguments: [locationId],
+                    }),
+                );
+            }
+
+            // Expand down (move endLine down by 1)
+            lenses.push(
+                new vscode.CodeLens(bottomRange, {
+                    title: "$(arrow-down) Expand",
+                    command: "weAudit.boundaryExpandDown",
+                    tooltip: "Expand finding boundary down by one line",
+                    arguments: [locationId],
+                }),
+            );
+
+            // Move down (shift entire region down by 1)
+            lenses.push(
+                new vscode.CodeLens(bottomRange, {
+                    title: "$(triangle-down) Move",
+                    command: "weAudit.boundaryMoveDown",
+                    tooltip: "Move entire finding down by one line",
+                    arguments: [locationId],
+                }),
+            );
+        } else {
+            // Single-line finding: show expand down on the same line
+            lenses.push(
+                new vscode.CodeLens(topRange, {
+                    title: "$(arrow-down) Expand Down",
+                    command: "weAudit.boundaryExpandDown",
+                    tooltip: "Expand finding boundary down by one line",
+                    arguments: [locationId],
+                }),
+            );
+        }
+
+        return lenses;
+    }
+}
+
+/** Singleton instance of the CodeLens provider */
+let codeLensProvider: FindingBoundaryCodeLensProvider | undefined;
+
+/**
+ * Gets or creates the singleton CodeLens provider instance.
+ * @returns the FindingBoundaryCodeLensProvider instance
+ */
+export function getCodeLensProvider(): FindingBoundaryCodeLensProvider {
+    if (!codeLensProvider) {
+        codeLensProvider = new FindingBoundaryCodeLensProvider();
+    }
+    return codeLensProvider;
+}
+
+/**
+ * Activates the finding boundary CodeLens feature.
+ * Registers the CodeLens provider and all related commands.
+ * @param context the extension context
+ * @param getLocationUnderCursor function to get the current finding under cursor
+ * @param modifyLocationBoundary function to modify a location's boundaries
+ */
+export function activateFindingBoundaryCodeLens(
+    context: vscode.ExtensionContext,
+    getLocationUnderCursor: () => FullEntry | FullLocationEntry | undefined,
+    modifyLocationBoundary: (entry: FullEntry, locationIndex: number, startLineDelta: number, endLineDelta: number, document: vscode.TextDocument) => boolean,
+): void {
+    const provider = getCodeLensProvider();
+
+    // Register the CodeLens provider for all text documents (file + untitled)
+    // Use a glob pattern so the provider also works in remote scenarios (where the scheme isn't "file")
+    const selector: vscode.DocumentSelector = [{ pattern: "**/*" }, { scheme: "untitled" }];
+    context.subscriptions.push(vscode.languages.registerCodeLensProvider(selector, provider));
+
+    // Command: Start editing finding boundary
+    context.subscriptions.push(
+        vscode.commands.registerCommand("weAudit.editFindingBoundary", () => {
+            const locationOrEntry = getLocationUnderCursor();
+            if (!locationOrEntry) {
+                return;
+            }
+
+            let entry: FullEntry;
+            let locationIndex: number;
+
+            if (isLocationEntry(locationOrEntry)) {
+                entry = locationOrEntry.parentEntry;
+                // Find the index of this location in the parent entry
+                locationIndex = entry.locations.indexOf(locationOrEntry.location);
+                if (locationIndex === -1) {
+                    vscode.window.showErrorMessage("weAudit: Could not find location in entry.");
+                    return;
+                }
+            } else if (isEntry(locationOrEntry)) {
+                entry = locationOrEntry;
+                // For a FullEntry, we edit the first location by default
+                // But we need to find which location the cursor is actually in
+                const editor = vscode.window.activeTextEditor;
+                if (!editor) {
+                    return;
+                }
+                const cursorLine = editor.selection.active.line;
+                locationIndex = entry.locations.findIndex((loc) => cursorLine >= loc.startLine && cursorLine <= loc.endLine);
+                if (locationIndex === -1) {
+                    locationIndex = 0; // Default to first location
+                }
+            } else {
+                return;
+            }
+
+            provider.startEditing(entry, locationIndex);
+        }),
+    );
+
+    // Command: Stop editing finding boundary
+    context.subscriptions.push(
+        vscode.commands.registerCommand("weAudit.stopEditingBoundary", () => {
+            provider.stopEditing();
+        }),
+    );
+
+    // Helper to get the active editor's document
+    const getActiveDocument = (): vscode.TextDocument | undefined => {
+        return vscode.window.activeTextEditor?.document;
+    };
+
+    const registerBoundaryCommand = (commandId: string, startDelta: number, endDelta: number): void => {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(commandId, () => {
+                const session = provider.getActiveSession();
+                const document = getActiveDocument();
+                if (!session || !document) {
+                    return;
+                }
+                if (modifyLocationBoundary(session.entry, session.locationIndex, startDelta, endDelta, document)) {
+                    provider.updateEntry(session.entry);
+                }
+            }),
+        );
+    };
+
+    registerBoundaryCommand("weAudit.boundaryExpandUp", -1, 0);
+    registerBoundaryCommand("weAudit.boundaryShrinkTop", 1, 0);
+    registerBoundaryCommand("weAudit.boundaryExpandDown", 0, 1);
+    registerBoundaryCommand("weAudit.boundaryShrinkBottom", 0, -1);
+    registerBoundaryCommand("weAudit.boundaryMoveUp", -1, -1);
+    registerBoundaryCommand("weAudit.boundaryMoveDown", 1, 1);
+
+    // Stop editing when switching to a different file
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            if (!provider.isEditing()) {
+                return;
+            }
+            const session = provider.getActiveSession();
+            if (session && editor && editor.document.uri.fsPath !== session.uri.fsPath) {
+                provider.stopEditing();
+            }
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeVisibleTextEditors(() => {
+            if (provider.isEditing()) {
+                provider.updateDecorationsForVisibleEditors();
+            }
+        }),
+    );
+}

--- a/test/extension/suite/activation.test.ts
+++ b/test/extension/suite/activation.test.ts
@@ -54,6 +54,15 @@ suite("Extension Activation", () => {
             "weAudit.exportFindingsInMarkdown",
             "weAudit.showMarkedFilesDayLog",
             "weAudit.navigateToNextPartiallyAuditedRegion",
+            // Boundary editing commands
+            "weAudit.editFindingBoundary",
+            "weAudit.stopEditingBoundary",
+            "weAudit.boundaryExpandUp",
+            "weAudit.boundaryShrinkTop",
+            "weAudit.boundaryMoveUp",
+            "weAudit.boundaryExpandDown",
+            "weAudit.boundaryShrinkBottom",
+            "weAudit.boundaryMoveDown",
             // Git config commands
             "weAudit.editClientRemote",
             "weAudit.editAuditRemote",

--- a/test/extension/suite/boundaryEditing.test.ts
+++ b/test/extension/suite/boundaryEditing.test.ts
@@ -1,0 +1,301 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import { userInfo } from "os";
+
+interface ConfigurationEntry {
+    path: string;
+    username: string;
+    root: { label: string };
+}
+
+/**
+ * Returns the absolute path to the current user's `.weaudit` file for the given workspace folder.
+ */
+function getWeauditFilePath(workspaceFolder: vscode.WorkspaceFolder): string {
+    const username = vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username;
+    return path.join(workspaceFolder.uri.fsPath, ".vscode", `${username}.weaudit`);
+}
+
+/**
+ * Writes a minimal `.weaudit` file containing a single finding in `src/sample.ts`.
+ */
+function writeWeauditWithFinding(workspaceFolder: vscode.WorkspaceFolder, startLine: number, endLine: number): void {
+    const filePath = getWeauditFilePath(workspaceFolder);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const payload = {
+        clientRemote: "",
+        gitRemote: "",
+        gitSha: "",
+        treeEntries: [
+            {
+                label: "Test Finding",
+                entryType: 0,
+                author: vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
+                locations: [{ path: "src/sample.ts", startLine, endLine, label: "", description: "" }],
+                details: { severity: "", difficulty: "", type: "", description: "", exploit: "", recommendation: "" },
+            },
+        ],
+        auditedFiles: [],
+        partiallyAuditedFiles: [],
+        resolvedEntries: [],
+    };
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+}
+
+/**
+ * Creates a `ConfigurationEntry` for the current user's `.weaudit` file in the provided workspace folder.
+ */
+function getCurrentUserConfigEntry(workspaceFolder: vscode.WorkspaceFolder): ConfigurationEntry {
+    const filePath = getWeauditFilePath(workspaceFolder);
+    const username = path.parse(filePath).name;
+    return {
+        path: filePath,
+        username,
+        root: { label: path.basename(workspaceFolder.uri.fsPath) },
+    };
+}
+
+suite("Boundary Editing CodeLens", () => {
+    const extensionId = "trailofbits.weaudit";
+    let testFileUri: vscode.Uri;
+    let workspaceFolder: vscode.WorkspaceFolder;
+    let originalWeauditContent: string | null = null;
+    let weauditFilePath: string;
+    let configEntry: ConfigurationEntry;
+    let isConfigLoaded = false;
+
+    suiteSetup(async () => {
+        const extension = vscode.extensions.getExtension(extensionId);
+        await extension?.activate();
+
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        assert.ok(workspaceFolders && workspaceFolders.length > 0, "Workspace folder should be available for extension tests");
+        workspaceFolder = workspaceFolders[0];
+        testFileUri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, "src", "sample.ts"));
+
+        weauditFilePath = getWeauditFilePath(workspaceFolder);
+        configEntry = getCurrentUserConfigEntry(workspaceFolder);
+        if (fs.existsSync(weauditFilePath)) {
+            originalWeauditContent = fs.readFileSync(weauditFilePath, "utf-8");
+        }
+    });
+
+    suiteTeardown(async () => {
+        await vscode.commands.executeCommand("weAudit.stopEditingBoundary");
+        if (isConfigLoaded) {
+            await vscode.commands.executeCommand("weAudit.toggleSavedFindings", configEntry);
+            isConfigLoaded = false;
+        }
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+
+        if (weauditFilePath) {
+            if (originalWeauditContent !== null) {
+                fs.writeFileSync(weauditFilePath, originalWeauditContent);
+            } else if (fs.existsSync(weauditFilePath)) {
+                fs.unlinkSync(weauditFilePath);
+            }
+            await vscode.commands.executeCommand("weAudit.findAndLoadConfigurationFiles");
+        }
+    });
+
+    setup(async () => {
+        await vscode.commands.executeCommand("weAudit.stopEditingBoundary");
+        if (isConfigLoaded) {
+            await vscode.commands.executeCommand("weAudit.toggleSavedFindings", configEntry);
+            isConfigLoaded = false;
+        }
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+
+        if (weauditFilePath) {
+            if (originalWeauditContent !== null) {
+                fs.writeFileSync(weauditFilePath, originalWeauditContent);
+            } else if (fs.existsSync(weauditFilePath)) {
+                fs.unlinkSync(weauditFilePath);
+            }
+        }
+    });
+
+    /**
+     * Opens the shared test file in an editor.
+     */
+    async function openTestFile(): Promise<vscode.TextEditor> {
+        const document = await vscode.workspace.openTextDocument(testFileUri);
+        return await vscode.window.showTextDocument(document);
+    }
+
+    /**
+     * Places the cursor on a given line (empty selection), matching normal user navigation.
+     */
+    function placeCursorOnLine(editor: vscode.TextEditor, line: number): void {
+        const pos = new vscode.Position(line, 0);
+        editor.selection = new vscode.Selection(pos, pos);
+    }
+
+    /**
+     * Places a minimal (1-character) selection on a given line.
+     * This is used as a fallback for environments where cursor-only selections don't intersect regions as expected.
+     */
+    function selectSingleCharacterOnLine(editor: vscode.TextEditor, line: number): void {
+        const text = editor.document.lineAt(line).text;
+        const endChar = text.length === 0 ? 0 : 1;
+        editor.selection = new vscode.Selection(new vscode.Position(line, 0), new vscode.Position(line, endChar));
+    }
+
+    /**
+     * Retrieves CodeLens commands for a given document URI, filtered to weAudit-provided lenses.
+     */
+    async function getWeauditCodeLensCommands(uri: vscode.Uri): Promise<string[]> {
+        const lenses = (await vscode.commands.executeCommand("vscode.executeCodeLensProvider", uri)) as vscode.CodeLens[];
+        return lenses.map((l) => l.command?.command).filter((c): c is string => typeof c === "string" && c.startsWith("weAudit."));
+    }
+
+    /**
+     * Polls until a given CodeLens command appears for a document, or throws on timeout.
+     */
+    async function waitForWeauditCodeLensCommand(uri: vscode.Uri, command: string, timeoutMs: number = 3000): Promise<string[]> {
+        const startTime = Date.now();
+        while (Date.now() - startTime < timeoutMs) {
+            const commands = await getWeauditCodeLensCommands(uri);
+            if (commands.includes(command)) {
+                return commands;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        const commands = await getWeauditCodeLensCommands(uri);
+        throw new Error(`Timed out waiting for CodeLens command "${command}". Got: ${JSON.stringify(commands)}`);
+    }
+
+    /**
+     * Polls until a given CodeLens command disappears for a document, or throws on timeout.
+     */
+    async function waitForWeauditCodeLensCommandAbsent(uri: vscode.Uri, command: string, timeoutMs: number = 3000): Promise<string[]> {
+        const startTime = Date.now();
+        while (Date.now() - startTime < timeoutMs) {
+            const commands = await getWeauditCodeLensCommands(uri);
+            if (!commands.includes(command)) {
+                return commands;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        const commands = await getWeauditCodeLensCommands(uri);
+        throw new Error(`Timed out waiting for CodeLens command "${command}" to disappear. Got: ${JSON.stringify(commands)}`);
+    }
+
+    /**
+     * Loads the seeded `.weaudit` file into the extension and starts boundary editing.
+     * This is resilient to prior test suites leaving the config selected: it toggles once,
+     * attempts to start editing, and if that fails it toggles again (reload) and retries.
+     */
+    async function loadSeededFindingAndStartEditing(editor: vscode.TextEditor, cursorLine: number, expectedLensCommand: string): Promise<string[]> {
+        await vscode.commands.executeCommand("weAudit.stopEditingBoundary");
+        placeCursorOnLine(editor, cursorLine);
+
+        await vscode.commands.executeCommand("weAudit.toggleSavedFindings", configEntry);
+        isConfigLoaded = true;
+
+        // Allow the extension to process the loaded findings before editing
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        try {
+            await vscode.commands.executeCommand("weAudit.editFindingBoundary");
+            return await waitForWeauditCodeLensCommand(editor.document.uri, expectedLensCommand, 2000);
+        } catch {
+            await vscode.commands.executeCommand("weAudit.stopEditingBoundary");
+            // Toggle twice: first unloads, second reloads findings from disk
+            await vscode.commands.executeCommand("weAudit.toggleSavedFindings", configEntry);
+            await vscode.commands.executeCommand("weAudit.toggleSavedFindings", configEntry);
+            isConfigLoaded = true;
+
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            selectSingleCharacterOnLine(editor, cursorLine);
+            await vscode.commands.executeCommand("weAudit.editFindingBoundary");
+            return await waitForWeauditCodeLensCommand(editor.document.uri, expectedLensCommand, 3000);
+        }
+    }
+
+    /**
+     * Returns the last line index that contains any non-whitespace text, or 0 if the document is empty/whitespace-only.
+     */
+    function getLastNonEmptyLine(document: vscode.TextDocument): number {
+        for (let i = document.lineCount - 1; i >= 0; i--) {
+            if (document.lineAt(i).text.trim().length > 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    test("Does not show Expand Down at EOF (single-line finding)", async function () {
+        this.timeout(20000);
+
+        const editor = await openTestFile();
+        const lastLineIndex = editor.document.lineCount - 1;
+        assert.ok(lastLineIndex >= 2, "Test file must contain at least 3 lines");
+
+        // Start boundary mode from a 2-line finding, then shrink it to a single-line finding one line above EOF.
+        // This avoids a flaky edge case where starting boundary editing directly on a single-line seeded finding
+        // sometimes fails to resolve the "finding under cursor" in the extension-host test environment.
+        const anchorLine = lastLineIndex - 1;
+        writeWeauditWithFinding(workspaceFolder, anchorLine - 1, anchorLine);
+        await loadSeededFindingAndStartEditing(editor, anchorLine, "weAudit.boundaryShrinkTop");
+
+        await vscode.commands.executeCommand("weAudit.boundaryShrinkTop");
+        await waitForWeauditCodeLensCommand(editor.document.uri, "weAudit.stopEditingBoundary");
+
+        const commandsAfterShrink = await getWeauditCodeLensCommands(editor.document.uri);
+        assert.ok(!commandsAfterShrink.includes("weAudit.boundaryShrinkTop"), "Expected the region to be single-line after shrinking from the top");
+        assert.ok(!commandsAfterShrink.includes("weAudit.boundaryShrinkBottom"), "Expected the region to be single-line after shrinking from the top");
+        assert.ok(commandsAfterShrink.includes("weAudit.boundaryExpandDown"), "Expand Down should be offered when not yet at end-of-file");
+
+        // Move the single-line finding down by one line so it reaches EOF, then verify Expand Down is hidden.
+        await vscode.commands.executeCommand("weAudit.boundaryMoveDown");
+        await waitForWeauditCodeLensCommand(editor.document.uri, "weAudit.stopEditingBoundary");
+        const commandsAtEof = await waitForWeauditCodeLensCommandAbsent(editor.document.uri, "weAudit.boundaryExpandDown", 5000);
+        assert.ok(!commandsAtEof.includes("weAudit.boundaryExpandDown"), "Expand Down should not be offered once the finding reaches end-of-file");
+    });
+
+    test("Does not show Expand/Move Down at EOF (multi-line finding)", async function () {
+        this.timeout(20000);
+
+        const editor = await openTestFile();
+        const lastNonEmptyLine = getLastNonEmptyLine(editor.document);
+        assert.ok(lastNonEmptyLine > 0, "Test file must contain at least 2 non-empty lines");
+        const lastLineIndex = editor.document.lineCount - 1;
+
+        writeWeauditWithFinding(workspaceFolder, lastNonEmptyLine - 1, lastNonEmptyLine);
+        const commands = await loadSeededFindingAndStartEditing(editor, lastNonEmptyLine, "weAudit.boundaryShrinkBottom");
+        assert.ok(commands.includes("weAudit.boundaryShrinkBottom"), "Shrink Bottom should be offered for multi-line findings");
+
+        if (lastNonEmptyLine === lastLineIndex) {
+            assert.ok(!commands.includes("weAudit.boundaryExpandDown"), "Expand Down should not be offered at end-of-file");
+            assert.ok(!commands.includes("weAudit.boundaryMoveDown"), "Move Down should not be offered at end-of-file");
+        } else {
+            assert.ok(commands.includes("weAudit.boundaryExpandDown"), "Expand Down should be offered when not yet at the document's last line");
+            assert.ok(commands.includes("weAudit.boundaryMoveDown"), "Move Down should be offered when not yet at the document's last line");
+
+            await vscode.commands.executeCommand("weAudit.boundaryExpandDown");
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            const commandsAtEof = await getWeauditCodeLensCommands(editor.document.uri);
+            assert.ok(!commandsAtEof.includes("weAudit.boundaryExpandDown"), "Expand Down should not be offered once the finding reaches end-of-file");
+            assert.ok(!commandsAtEof.includes("weAudit.boundaryMoveDown"), "Move Down should not be offered once the finding reaches end-of-file");
+        }
+    });
+
+    test("Closing all editors exits boundary editing mode", async function () {
+        this.timeout(25000);
+
+        const editor = await openTestFile();
+        writeWeauditWithFinding(workspaceFolder, 5, 6);
+        await loadSeededFindingAndStartEditing(editor, 5, "weAudit.stopEditingBoundary");
+
+        await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        const reopened = await openTestFile();
+        const commandsAfterClose = await getWeauditCodeLensCommands(reopened.document.uri);
+        assert.deepStrictEqual(commandsAfterClose, [], "Expected no boundary editing CodeLens after closing all editors");
+    });
+});


### PR DESCRIPTION
This PR introduces a feature that allows changing the boundary of a weAudit region using keybinds or a CodeLens interface.

<img width="681" height="264" alt="image" src="https://github.com/user-attachments/assets/c0118c59-635a-447c-8fdd-709aba0acfc0" />



Test Instructions for Reviewers

- Reload VS Code with the extension installed or run it via F5.
- Create a finding, place the cursor inside it, and press the boundary shortcuts (cmd/ctrl+shift+numpad7 etc.); Alternatively, start the editing session with "weAudit: Edit Finding Boundary" command
- verify the region expands/shrinks even if you didn’t run “Edit Finding Boundary” first.
- Use the CodeLens buttons or the keybinds for the commands
