### PR TITLE
Add contextValue to findings and notes in tree view

### DIFF
--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -3753,6 +3753,8 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             arguments: [vscode.Uri.file(path.join(mainLocation.rootPath, mainLocation.path)), mainLocation.startLine, mainLocation.endLine],
         };
 
+        treeItem.contextValue = entry.entryType === EntryType.Note ? "note" : "finding";
+
         return treeItem;
     }
 


### PR DESCRIPTION
## Summary
- Adds `contextValue` property to findings and notes in the tree view
- Findings get `contextValue = "finding"`, notes get `contextValue = "note"`
- Ensures context menu items (Resolve, Delete, etc.) work correctly in GroupByFile mode

## Test plan
- [ ] Switch tree view to "Group by File" mode
- [ ] Right-click on a finding
- [ ] Verify "Resolve Finding" appears in the context menu
- [ ] Verify the resolve action works correctly

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)