### PR TITLE
feat: add documentation generation with LLM and overlay in editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.3.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
-                "@anthropic-ai/claude-agent-sdk": "^0.2.47",
+                "@anthropic-ai/claude-agent-sdk": "^0.2.49",
                 "@vscode/webview-ui-toolkit": "^1.4.0",
                 "asciichart": "^1.5.25"
             },
@@ -45,9 +45,9 @@
             }
         },
         "node_modules/@anthropic-ai/claude-agent-sdk": {
-            "version": "0.2.47",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.47.tgz",
-            "integrity": "sha512-tcptBQwLnaUv6f5KiiUUtGduiLUhwV/xT0kPxVG+K2Wws1T/2MLViwIoti3AkJuNJ2qZ5FOwl1YQLHPMeHlYVQ==",
+            "version": "0.2.49",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.49.tgz",
+            "integrity": "sha512-3avi409dwuGkPEETpWa0gyJvRMr3b6LxeuW5/sAPCOtLD9WxH9fYltbA5wZoazxTw5mlbXmjDp7JqO1rlmpaIQ==",
             "license": "SEE LICENSE IN README.md",
             "engines": {
                 "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.3.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
+                "@anthropic-ai/claude-agent-sdk": "^0.2.47",
                 "@vscode/webview-ui-toolkit": "^1.4.0",
                 "asciichart": "^1.5.25"
             },
@@ -41,6 +42,29 @@
             },
             "engines": {
                 "vscode": "^1.108.0"
+            }
+        },
+        "node_modules/@anthropic-ai/claude-agent-sdk": {
+            "version": "0.2.47",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.47.tgz",
+            "integrity": "sha512-tcptBQwLnaUv6f5KiiUUtGduiLUhwV/xT0kPxVG+K2Wws1T/2MLViwIoti3AkJuNJ2qZ5FOwl1YQLHPMeHlYVQ==",
+            "license": "SEE LICENSE IN README.md",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "^0.34.2",
+                "@img/sharp-darwin-x64": "^0.34.2",
+                "@img/sharp-linux-arm": "^0.34.2",
+                "@img/sharp-linux-arm64": "^0.34.2",
+                "@img/sharp-linux-x64": "^0.34.2",
+                "@img/sharp-linuxmusl-arm64": "^0.34.2",
+                "@img/sharp-linuxmusl-x64": "^0.34.2",
+                "@img/sharp-win32-arm64": "^0.34.2",
+                "@img/sharp-win32-x64": "^0.34.2"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.0"
             }
         },
         "node_modules/@azu/format-text": {
@@ -260,6 +284,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1444,6 +1469,310 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -2109,6 +2438,7 @@
             "integrity": "sha512-clwXbTAykhqJqUkdTWUtS7jwY1eQVhlgQia6GfmMHMLGxqMbHCgHVm0rEYoR1C050XWYxtfsEpnsmUB9Kjcs9A==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "clipboardy": "^5.0.2",
                 "clone-deep": "^4.0.1",
@@ -2640,6 +2970,7 @@
             "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -2745,6 +3076,7 @@
             "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.55.0",
                 "@typescript-eslint/types": "8.55.0",
@@ -3354,6 +3686,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3749,6 +4082,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5072,6 +5406,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9331,6 +9666,7 @@
                 }
             ],
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@bazel/runfiles": "^6.5.0",
                 "jszip": "^3.10.1",
@@ -10635,6 +10971,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11480,6 +11817,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
                     "id": "savedFindings",
                     "name": "weAudit Files",
                     "contextualTitle": "weAudit"
+                },
+                {
+                    "type": "webview",
+                    "id": "docsOverlay",
+                    "name": "Docs Overlay",
+                    "contextualTitle": "weAudit"
                 }
             ]
         },
@@ -272,6 +278,21 @@
             {
                 "command": "weAudit.boundaryMoveDown",
                 "title": "weAudit: Move Finding Down"
+            },
+            {
+                "command": "weAudit.generateDocOverlay",
+                "title": "Open Docs Overlay",
+                "category": "weAudit"
+            },
+            {
+                "command": "weAudit.toggleDocOverlay",
+                "title": "Toggle Documentation Overlay Visibility",
+                "category": "weAudit"
+            },
+            {
+                "command": "weAudit.clearDocOverlay",
+                "title": "Clear All Documentation Overlays",
+                "category": "weAudit"
             }
         ],
         "keybindings": [
@@ -605,6 +626,22 @@
                 }
             },
             {
+                "title": "Documentation Overlay",
+                "order": 3,
+                "properties": {
+                    "weAudit.docOverlay.visibleOnLoad": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Show documentation overlays automatically when a session is loaded."
+                    },
+                    "weAudit.docOverlay.anthropicApiKey": {
+                        "type": "string",
+                        "default": "",
+                        "markdownDescription": "Anthropic API key used for documentation overlay generation. Set this instead of the `ANTHROPIC_API_KEY` environment variable."
+                    }
+                }
+            },
+            {
                 "title": "Highlight colors",
                 "order": 2,
                 "properties": {
@@ -685,6 +722,7 @@
         "vscode-extension-tester": "^8.21.0"
     },
     "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.47",
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "asciichart": "^1.5.25"
     }

--- a/package.json
+++ b/package.json
@@ -722,7 +722,7 @@
         "vscode-extension-tester": "^8.21.0"
     },
     "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.47",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.49",
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "asciichart": "^1.5.25"
     }

--- a/src/docOverlay/agentRunner.ts
+++ b/src/docOverlay/agentRunner.ts
@@ -1,0 +1,264 @@
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import * as vscode from "vscode";
+
+import { type DocEntry, isValidDocEntry } from "./types";
+
+/** Options passed to runDocumentationAgent. */
+export interface AgentRunOpts {
+    /** Plugin install directory passed to query() plugins option. */
+    skillPluginPath: string;
+    /** Skill name for slash-command invocation in the prompt. */
+    skillName: string;
+    targetDir: string;
+    workspaceRoot: string;
+    /** Absolute path to the claude CLI binary. */
+    claudeBinaryPath: string;
+    /** Anthropic API key from VS Code configuration. */
+    apiKey: string;
+    /** Called with a human-readable progress message during generation. */
+    onProgress: (message: string, truncate: boolean) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Claude binary detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to locate the Claude Code CLI binary without blocking the UI.
+ * Detection order:
+ *   1. `CLAUDE_BINARY` environment variable
+ *   2. `claude-code.binaryPath` VS Code setting (Claude Code extension config)
+ *   3. Common installation paths (~/.local/bin, /usr/local/bin, Homebrew, etc.)
+ *   4. `which claude` / `where claude` shell lookup (last resort — spawns a subprocess)
+ * @returns The resolved absolute path, or an empty string if not found.
+ */
+export function detectClaudeBinary(): string {
+    // 1. Explicit env var override.
+    const fromEnv = process.env["CLAUDE_BINARY"]?.trim();
+    if (fromEnv && fs.existsSync(fromEnv)) {
+        return fromEnv;
+    }
+
+    // 2. VS Code extension configuration (Claude Code extension).
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const vscodeModule = require("vscode") as typeof vscode;
+        for (const key of ["binaryPath", "executablePath", "cliPath"]) {
+            const fromConfig = vscodeModule.workspace.getConfiguration("claude-code").get<string>(key, "").trim();
+            if (fromConfig && fs.existsSync(fromConfig)) {
+                return fromConfig;
+            }
+        }
+    } catch {
+        // Not in VS Code host (e.g., unit tests) — skip.
+    }
+
+    // 3. Common installation paths.
+    const home = os.homedir();
+    const candidates: string[] = [
+        path.join(home, ".local", "bin", "claude"),
+        path.join(home, ".npm-global", "bin", "claude"),
+        "/usr/local/bin/claude",
+        "/opt/homebrew/bin/claude",
+        "/usr/bin/claude",
+    ];
+    if (process.platform === "win32") {
+        candidates.push(path.join(home, "AppData", "Roaming", "npm", "claude.cmd"), path.join(home, "AppData", "Local", "Programs", "claude", "claude.exe"));
+    }
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    // 4. Shell which/where lookup (spawns a subprocess — fast, 2 s timeout).
+    try {
+        const cmd = process.platform === "win32" ? "where claude" : "which claude";
+        const result = childProcess.execSync(cmd, { encoding: "utf-8", timeout: 2000 }).trim().split("\n")[0]?.trim() ?? "";
+        if (result && fs.existsSync(result)) {
+            return result;
+        }
+    } catch {
+        // Binary not on PATH.
+    }
+
+    return "";
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the documentation agent over the target directory using the query() API
+ * from @anthropic-ai/claude-agent-sdk, which runs Claude Code as a subprocess.
+ *
+ * The agent is given Read and Glob tools and autonomously explores the target
+ * directory, generating a JSON array of DocEntry objects. Generation is aborted
+ * when the cancellation token fires.
+ *
+ * @param opts Agent run options including skill plugin path and target directory.
+ * @param token VS Code cancellation token used to abort the loop.
+ * @returns Array of validated DocEntry objects produced by the agent.
+ */
+export async function runDocumentationAgent(opts: AgentRunOpts, token: vscode.CancellationToken): Promise<DocEntry[]> {
+    // Lazy-require to avoid needing the SDK in unit-test contexts.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { query } = require("@anthropic-ai/claude-agent-sdk") as typeof import("@anthropic-ai/claude-agent-sdk");
+
+    const abortController = new AbortController();
+    const cancelListener = token.onCancellationRequested(() => abortController.abort());
+
+    // Merge process.env so the subprocess has PATH, HOME, etc., but override the API key.
+    const env: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined) {
+            env[k] = v;
+        }
+    }
+    env["ANTHROPIC_API_KEY"] = opts.apiKey;
+
+    opts.onProgress("Starting documentation agent", false);
+
+    try {
+        const messages = query({
+            prompt: buildPrompt(opts.skillName, opts.targetDir, opts.workspaceRoot),
+            options: {
+                cwd: opts.workspaceRoot,
+                pathToClaudeCodeExecutable: opts.claudeBinaryPath,
+                plugins: [{ type: "local", path: opts.skillPluginPath }],
+                env,
+                permissionMode: "bypassPermissions",
+                allowDangerouslySkipPermissions: true,
+                abortController,
+                allowedTools: ["Read", "Glob", "Grep"],
+            },
+        });
+
+        let roundCount = 0;
+        for await (const msg of messages) {
+            if (token.isCancellationRequested) {
+                break;
+            }
+            // Cast through unknown — the SDK's BetaMessage type depends on
+            // @anthropic-ai/sdk which is not resolvable in this project.
+            const rawMsg = msg as unknown as Record<string, unknown>;
+
+            if (rawMsg["type"] === "assistant") {
+                roundCount++;
+                opts.onProgress(`— Round ${roundCount} —`, false);
+                const content = (rawMsg["message"] as Record<string, unknown>)["content"];
+                const blocks = (content as Array<Record<string, unknown>>) ?? [];
+                for (const block of blocks) {
+                    if (block["type"] === "text") {
+                        const text = (block["text"] as string | undefined)?.trim();
+                        if (text) {
+                            opts.onProgress(`Text: ${text}`, false);
+                        }
+                    }
+                    if (block["type"] === "thinking") {
+                        const thinking = (block["thinking"] as string | undefined)?.trim();
+                        if (thinking) {
+                            opts.onProgress(`Thinking ${thinking}`, true);
+                        }
+                    }
+                    if (block["type"] === "tool_use") {
+                        const name = (block["name"] as string | undefined)?.trim();
+                        if (name) {
+                            opts.onProgress(`Tool use: ${name} ${JSON.stringify(block["input"])}`, true);
+                        }
+                    }
+                }
+            }
+            if (rawMsg["type"] === "result") {
+                if (rawMsg["subtype"] === "success") {
+                    return parseEntries(rawMsg["result"] as string);
+                }
+                const errors = "errors" in rawMsg ? (rawMsg["errors"] as string[]).join(", ") : (rawMsg["subtype"] as string);
+                throw new Error(`Agent failed (${rawMsg["subtype"] as string}): ${errors}`);
+            }
+        }
+
+        if (token.isCancellationRequested) {
+            throw new Error("Documentation generation was cancelled.");
+        }
+        return [];
+    } finally {
+        cancelListener.dispose();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the prompt for the documentation agent, invoking the named skill
+ * as a slash command and describing the expected JSON output format.
+ * @param skillName The slash-command name of the installed skill.
+ * @param targetDir Absolute path to the directory to document.
+ * @param workspaceRoot Absolute path to the workspace root.
+ * @returns The full prompt string to pass to query().
+ */
+export function buildPrompt(skillName: string, targetDir: string, workspaceRoot: string): string {
+    return `/${skillName} Generate documentation for all source files in: ${targetDir}
+
+Workspace root: ${workspaceRoot}
+
+Use the Read and Glob tools to explore and read source files.
+After reading the relevant files, output ONLY a JSON array of documentation entries
+with this exact schema — no other text before or after the array:
+
+[
+  {
+    "type": "function" | "file",
+    "path": "<path relative to workspace root>",
+    "startLine": <0-indexed integer>,
+    "endLine": <0-indexed integer, inclusive>,
+    "functionName": "<name if type is function, otherwise omit>",
+    "summary": "<1-2 sentence summary for inline ghost text>",
+    "fullDoc": "<full markdown documentation>",
+    "generatedAt": "<ISO 8601 timestamp>",
+    "skill": "<skill name>"
+  }
+]
+
+In fullDoc, use the markdown in the same output format as specified by the ${skillName} skill.`;
+}
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
+
+export function parseEntries(responseText: string): DocEntry[] {
+    const jsonMatch = responseText.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) {
+        // Lazy-require vscode for warning message.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const vscodeModule = require("vscode") as typeof vscode;
+        void vscodeModule.window.showWarningMessage("weAudit docOverlay: Agent did not produce a JSON array. No entries saved.");
+        return [];
+    }
+
+    let parsed: unknown[];
+    try {
+        parsed = JSON.parse(jsonMatch[0]) as unknown[];
+    } catch {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const vscodeModule = require("vscode") as typeof vscode;
+        void vscodeModule.window.showWarningMessage("weAudit docOverlay: Agent produced malformed JSON. No entries saved.");
+        return [];
+    }
+
+    return parsed.filter((e): e is DocEntry => {
+        const valid = isValidDocEntry(e);
+        if (!valid) {
+            console.log("weAudit docOverlay: skipping invalid entry:", e);
+        }
+        return valid;
+    });
+}

--- a/src/docOverlay/decorations.ts
+++ b/src/docOverlay/decorations.ts
@@ -1,0 +1,71 @@
+import * as path from "path";
+
+import type * as vscode from "vscode";
+
+import type { DocEntry } from "./types";
+
+const SPACE = "\u00a0";
+const DOC_GHOST_COLOR_DARK = "#6699cc88";
+const DOC_GHOST_COLOR_LIGHT = "#33669988";
+
+/**
+ * Creates the decoration type used for all documentation overlay ghost text.
+ * Uses an empty base style; all visual output is carried by per-decoration renderOptions.
+ * @returns A TextEditorDecorationType for doc overlays.
+ */
+export function createDocOverlayDecorationType(): vscode.TextEditorDecorationType {
+    // Lazy-require so this module is loadable outside a VS Code host.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const vscodeModule = require("vscode") as typeof vscode;
+    return vscodeModule.window.createTextEditorDecorationType({});
+}
+
+/**
+ * Builds decoration options for all doc entries that match the given file.
+ * Each matching entry produces one ghost-text decoration at its startLine.
+ * @param entries All loaded DocEntry objects.
+ * @param filePath Absolute filesystem path of the file being decorated.
+ * @param workspaceRoot Absolute workspace root for resolving relative entry paths.
+ * @returns Array of DecorationOptions ready to pass to editor.setDecorations().
+ */
+export function buildDocDecorations(entries: DocEntry[], filePath: string, workspaceRoot: string): vscode.DecorationOptions[] {
+    const decorations: vscode.DecorationOptions[] = [];
+
+    for (const entry of entries) {
+        const entryAbsPath = resolveEntryPath(entry.path, workspaceRoot);
+        if (entryAbsPath !== filePath) {
+            continue;
+        }
+        decorations.push(buildDecoration(entry));
+    }
+
+    return decorations;
+}
+
+function buildDecoration(entry: DocEntry): vscode.DecorationOptions {
+    const label = entry.functionName ? `${entry.functionName}: ${entry.summary}` : entry.summary;
+    const contentText = ("      " + label).replace(/ /g, SPACE);
+
+    // Construct a range-shaped object structurally compatible with vscode.Range.
+    // At runtime inside VS Code this satisfies setDecorations; in unit tests it
+    // lets us inspect line values without needing the real vscode module.
+    const range = {
+        start: { line: entry.startLine, character: 0 },
+        end: { line: entry.startLine, character: Number.MAX_SAFE_INTEGER },
+    } as unknown as vscode.Range;
+
+    return {
+        range,
+        renderOptions: {
+            dark: { after: { contentText, color: DOC_GHOST_COLOR_DARK } },
+            light: { after: { contentText, color: DOC_GHOST_COLOR_LIGHT } },
+        },
+    };
+}
+
+function resolveEntryPath(entryRelPath: string, workspaceRoot: string): string {
+    if (path.isAbsolute(entryRelPath)) {
+        return entryRelPath;
+    }
+    return path.resolve(workspaceRoot, entryRelPath);
+}

--- a/src/docOverlay/docOverlayManager.ts
+++ b/src/docOverlay/docOverlayManager.ts
@@ -1,0 +1,243 @@
+import * as vscode from "vscode";
+
+import { detectClaudeBinary, runDocumentationAgent } from "./agentRunner";
+import { buildDocDecorations, createDocOverlayDecorationType } from "./decorations";
+import { DocStore } from "./docStore";
+import { DocOverlayPanel, type LogEntry, type LogEntryType } from "./docOverlayPanel";
+import { DocOverlayHoverProvider } from "./hoverProvider";
+import type { DocEntry } from "./types";
+
+/**
+ * Manages the documentation overlay feature: generation, persistence, decorations, and hover tooltips.
+ * Registers the three weAudit.generateDocOverlay / toggleDocOverlay / clearDocOverlay commands
+ * and keeps all visible editors in sync with the current set of loaded doc entries.
+ *
+ * Owns all panel state (skillName, pluginDir, targetDir, log) and supplies it to
+ * DocOverlayPanel via a getState callback so the panel can reconstruct its UI on every reopen.
+ */
+export class DocOverlayManager {
+    private entries: DocEntry[] = [];
+    private visible: boolean;
+    private readonly docDecorationType: vscode.TextEditorDecorationType;
+    private readonly docStore: DocStore;
+    private readonly workspaceRoot: string;
+
+    // Panel state — owned here so it survives panel close/reopen cycles.
+    private _claudeBinaryPath = "";
+    private _skillName = "";
+    private _pluginDir = "";
+    private _targetDir = "";
+    private _log: LogEntry[] = [];
+    private _panel?: DocOverlayPanel;
+
+    /** @param context The extension context used for registering disposables. */
+    constructor(context: vscode.ExtensionContext) {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders || workspaceFolders.length === 0) {
+            // No workspace open; nothing to do.
+            this.visible = false;
+            this.workspaceRoot = "";
+            this.docDecorationType = vscode.window.createTextEditorDecorationType({});
+            this.docStore = new DocStore("");
+            return;
+        }
+
+        this.workspaceRoot = workspaceFolders[0].uri.fsPath;
+        this.docStore = new DocStore(this.workspaceRoot);
+        this._claudeBinaryPath = detectClaudeBinary();
+
+        const config = vscode.workspace.getConfiguration("weAudit");
+        this.visible = config.get<boolean>("docOverlay.visibleOnLoad", true);
+
+        this.docDecorationType = createDocOverlayDecorationType();
+        context.subscriptions.push(this.docDecorationType);
+
+        // Hover provider: supplies fullDoc markdown on cursor hover.
+        const hoverProvider = new DocOverlayHoverProvider(() => this.entries, this.workspaceRoot);
+        const hoverDisposable = vscode.languages.registerHoverProvider({ scheme: "file" }, hoverProvider);
+        context.subscriptions.push(hoverDisposable);
+
+        // Sidebar panel: stateless renderer — all state is owned by this manager.
+        const panel = new DocOverlayPanel(
+            context.extensionUri,
+            (skillName, pluginDir, targetDir) => void this.runGeneration(skillName, pluginDir, targetDir),
+            (field, value) => {
+                if (field === "claudeBinaryPath") {
+                    this._claudeBinaryPath = value;
+                } else if (field === "skillName") {
+                    this._skillName = value;
+                } else if (field === "pluginDir") {
+                    this._pluginDir = value;
+                } else if (field === "targetDir") {
+                    this._targetDir = value;
+                }
+            },
+            () => ({
+                claudeBinaryPath: this._claudeBinaryPath,
+                skillName: this._skillName,
+                pluginDir: this._pluginDir,
+                targetDir: this._targetDir,
+                log: this._log,
+                overlayVisible: this.visible,
+                hasDocs: this.entries.length > 0,
+            }),
+            this.workspaceRoot,
+        );
+        this._panel = panel;
+        context.subscriptions.push(vscode.window.registerWebviewViewProvider("docsOverlay", panel));
+
+        // Command registrations.
+        context.subscriptions.push(
+            vscode.commands.registerCommand("weAudit.generateDocOverlay", () => {
+                void vscode.commands.executeCommand("docsOverlay.focus");
+            }),
+            vscode.commands.registerCommand("weAudit.toggleDocOverlay", () => this.toggleDocOverlay()),
+            vscode.commands.registerCommand("weAudit.clearDocOverlay", () => this.clearDocOverlay()),
+        );
+
+        // Decorate newly opened/activated editors.
+        context.subscriptions.push(
+            vscode.window.onDidChangeActiveTextEditor((editor) => {
+                if (editor) {
+                    this.decorateEditor(editor);
+                }
+            }),
+        );
+
+        // Reload when weaudit-docs/ changes on disk (e.g. session copied in externally).
+        const watcher = this.docStore.watchForChanges(() => this.reloadAndRedecorate());
+        context.subscriptions.push(watcher);
+
+        // Load any sessions that were persisted from a previous run.
+        this.reloadAndRedecorate();
+    }
+
+    /**
+     * Appends an entry to the in-memory log and forwards it to the panel if open.
+     * @param text Message text (may contain newlines).
+     * @param type Visual style: "info", or "error".
+     */
+    private _appendLog(text: string, type: LogEntryType = "info"): void {
+        this._log.push({ type, text });
+        this._panel?.appendLog(text, type);
+    }
+
+    /** Pushes current overlay visibility and docs availability to the live panel. */
+    private _syncPanelState(): void {
+        this._panel?.syncState(this.visible, this.entries.length > 0);
+    }
+
+    /**
+     * Runs the documentation agent with the values provided by the sidebar panel.
+     * Reports progress via panel log messages and VS Code progress notifications.
+     * @param skillName Name of the skill to invoke.
+     * @param pluginDir Absolute path to the plugin directory.
+     * @param targetDir Absolute path to the directory to document.
+     */
+    private async runGeneration(skillName: string, pluginDir: string, targetDir: string): Promise<void> {
+        const config = vscode.workspace.getConfiguration("weAudit");
+        const apiKey = config.get<string>("docOverlay.anthropicApiKey", "").trim();
+        if (!apiKey) {
+            this._appendLog("Error: set weAudit › Doc Overlay › Anthropic API Key in settings.", "error");
+            return;
+        }
+        if (!this.workspaceRoot) {
+            this._appendLog("Error: no workspace open.", "error");
+            return;
+        }
+
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: "weAudit: Generating documentation for overlay",
+                cancellable: true,
+            },
+            async (progress, token) => {
+                let entries: DocEntry[];
+                try {
+                    entries = await runDocumentationAgent(
+                        {
+                            skillPluginPath: pluginDir,
+                            skillName,
+                            targetDir,
+                            workspaceRoot: this.workspaceRoot,
+                            claudeBinaryPath: this._claudeBinaryPath,
+                            apiKey,
+                            onProgress: (msg, truncate) => {
+                                const progressMsg = truncate ? (msg.split("\n")[0] ?? msg) + " …" : msg;
+                                progress.report({ message: `${progressMsg}` });
+                                this._appendLog(msg, "info");
+                            },
+                        },
+                        token,
+                    );
+                } catch (err) {
+                    const msg = `Error: ${String(err)}`;
+                    this._appendLog(msg, "error");
+                    void vscode.window.showErrorMessage(`weAudit: ${msg}`);
+                    return;
+                }
+
+                if (token.isCancellationRequested) {
+                    this._appendLog("Cancelled.", "info");
+                    return;
+                }
+
+                const relativeTarget = vscode.workspace.asRelativePath(targetDir, false);
+                this.docStore.persistSession({
+                    version: 1,
+                    skill: skillName,
+                    targetDirectory: relativeTarget,
+                    generatedAt: new Date().toISOString(),
+                    workspaceRoot: this.workspaceRoot,
+                    entries,
+                });
+                this.reloadAndRedecorate();
+                this._appendLog(`Done — ${entries.length} entries generated.`, "info");
+            },
+        );
+    }
+
+    /** Flips overlay visibility and redecorates all visible editors. */
+    private toggleDocOverlay(): void {
+        this.visible = !this.visible;
+        this.redecorateAllEditors();
+        this._syncPanelState();
+    }
+
+    /** Deletes all persisted sessions, clears in-memory entries, and removes decorations. */
+    private clearDocOverlay(): void {
+        this.docStore.clearAllSessions();
+        this.entries = [];
+        this.redecorateAllEditors();
+        this._syncPanelState();
+    }
+
+    /** Reads all persisted sessions from disk and redecorates all visible editors. */
+    private reloadAndRedecorate(): void {
+        const sessions = this.docStore.loadAllSessions();
+        this.entries = sessions.flatMap((s) => s.entries);
+        this.redecorateAllEditors();
+        this._syncPanelState();
+    }
+
+    /** Applies or clears decorations on every currently visible text editor. */
+    private redecorateAllEditors(): void {
+        for (const editor of vscode.window.visibleTextEditors) {
+            this.decorateEditor(editor);
+        }
+    }
+
+    /**
+     * Applies doc overlay decorations to a single editor, or clears them when hidden.
+     * @param editor The text editor to decorate.
+     */
+    private decorateEditor(editor: vscode.TextEditor): void {
+        if (!this.visible) {
+            editor.setDecorations(this.docDecorationType, []);
+            return;
+        }
+        const decorations = buildDocDecorations(this.entries, editor.document.uri.fsPath, this.workspaceRoot);
+        editor.setDecorations(this.docDecorationType, decorations);
+    }
+}

--- a/src/docOverlay/docOverlayPanel.ts
+++ b/src/docOverlay/docOverlayPanel.ts
@@ -1,0 +1,396 @@
+import * as crypto from "crypto";
+
+import * as vscode from "vscode";
+
+/** Discriminates log entry display style. */
+export type LogEntryType = "assistant" | "info" | "error";
+
+/** A single entry in the activity log. */
+export interface LogEntry {
+    type: LogEntryType;
+    text: string;
+}
+
+/** Complete state the panel needs to render itself. Owned by DocOverlayManager. */
+export interface PanelState {
+    claudeBinaryPath: string;
+    skillName: string;
+    pluginDir: string;
+    targetDir: string;
+    log: ReadonlyArray<LogEntry>;
+    overlayVisible: boolean;
+    hasDocs: boolean;
+}
+
+/** Messages sent from the webview to the extension host. */
+type WebviewToExtMsg =
+    | { command: "browse"; field: "pluginDir" | "targetDir" }
+    | { command: "generate"; claudeBinaryPath: string; pluginDir: string; skillName: string; targetDir: string }
+    | { command: "toggle-overlay" }
+    | { command: "clear-docs" };
+
+/** Messages sent from the extension host to the webview. */
+type ExtToWebviewMsg =
+    | { command: "set-field"; field: "pluginDir" | "targetDir"; value: string }
+    | { command: "append-log"; logType: LogEntryType; text: string }
+    | { command: "sync-state"; overlayVisible: boolean; hasDocs: boolean };
+
+/**
+ * Sidebar WebviewViewProvider for the "Docs Overlay" panel.
+ * Stateless presentation layer: all state is owned by DocOverlayManager and
+ * supplied via getState. Field changes are reported back via onFieldUpdate.
+ */
+export class DocOverlayPanel implements vscode.WebviewViewProvider {
+    private _view?: vscode.WebviewView;
+
+    /**
+     * @param extensionUri Root URI of the extension (for CSP).
+     * @param onGenerate Called when the user clicks "Generate Docs".
+     * @param onFieldUpdate Called whenever a single field value changes (browse or generate).
+     * @param getState Returns current state from the manager to render on (re)open.
+     * @param workspaceRoot Absolute workspace root used as the default browse directory.
+     */
+    constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly onGenerate: (skillName: string, pluginDir: string, targetDir: string) => void,
+        private readonly onFieldUpdate: (field: "claudeBinaryPath" | "skillName" | "pluginDir" | "targetDir", value: string) => void,
+        private readonly getState: () => PanelState,
+        private readonly workspaceRoot: string,
+    ) {}
+
+    /** Called by VS Code when the view becomes visible for the first time or after disposal. */
+    public resolveWebviewView(webviewView: vscode.WebviewView, _context: vscode.WebviewViewResolveContext, _token: vscode.CancellationToken): void {
+        this._view = webviewView;
+        webviewView.onDidDispose(() => {
+            this._view = undefined;
+        });
+
+        webviewView.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [this.extensionUri],
+        };
+
+        // Rebuild HTML with current state whenever the panel becomes visible.
+        // VS Code retains the webview when collapsed (resolveWebviewView is not re-called),
+        // so onDidChangeVisibility is the only reliable hook for syncing retained views.
+        webviewView.onDidChangeVisibility(() => {
+            if (webviewView.visible) {
+                webviewView.webview.html = this._buildHtml();
+            }
+        });
+
+        // Full history is baked into the HTML so it's visible immediately on first open.
+        webviewView.webview.html = this._buildHtml();
+        webviewView.webview.onDidReceiveMessage((msg: WebviewToExtMsg) => this._handleMessage(msg));
+    }
+
+    /**
+     * Forwards a log entry to the live webview. Storage is the manager's responsibility.
+     * @param text Message text (may contain newlines).
+     * @param type Visual style: "assistant" (LLM output), "info" (progress), or "error".
+     */
+    public appendLog(text: string, type: LogEntryType = "info"): void {
+        this._post({ command: "append-log", logType: type, text });
+    }
+
+    /**
+     * Pushes overlay visibility and docs availability to the live webview so
+     * button colours and disabled state stay in sync without a full HTML rebuild.
+     * @param overlayVisible Whether the doc overlay is currently shown.
+     * @param hasDocs Whether any doc entries exist.
+     */
+    public syncState(overlayVisible: boolean, hasDocs: boolean): void {
+        this._post({ command: "sync-state", overlayVisible, hasDocs });
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helpers
+    // ---------------------------------------------------------------------------
+
+    private _post(msg: ExtToWebviewMsg): void {
+        this._view?.webview.postMessage(msg);
+    }
+
+    private async _handleMessage(msg: WebviewToExtMsg): Promise<void> {
+        if (msg.command === "browse") {
+            const defaultUri = this.workspaceRoot ? vscode.Uri.file(this.workspaceRoot) : undefined;
+
+            const uris = await vscode.window.showOpenDialog({
+                canSelectFiles: false,
+                canSelectFolders: true,
+                canSelectMany: false,
+                defaultUri,
+                title: msg.field === "pluginDir" ? "Select plugin directory" : "Select target directory",
+            });
+
+            const chosen = uris?.[0]?.fsPath;
+            if (chosen) {
+                this.onFieldUpdate(msg.field, chosen);
+                this._post({ command: "set-field", field: msg.field, value: chosen });
+            }
+            return;
+        }
+
+        if (msg.command === "generate") {
+            this.onFieldUpdate("claudeBinaryPath", msg.claudeBinaryPath);
+            this.onFieldUpdate("skillName", msg.skillName);
+            this.onFieldUpdate("pluginDir", msg.pluginDir);
+            this.onFieldUpdate("targetDir", msg.targetDir);
+            this.onGenerate(msg.skillName, msg.pluginDir, msg.targetDir);
+            return;
+        }
+
+        if (msg.command === "toggle-overlay") {
+            void vscode.commands.executeCommand("weAudit.toggleDocOverlay");
+            return;
+        }
+
+        if (msg.command === "clear-docs") {
+            const answer = await vscode.window.showWarningMessage(
+                "Clear all generated docs? This will delete all overlay entries and cannot be undone.",
+                { modal: true },
+                "Clear",
+            );
+            if (answer === "Clear") {
+                void vscode.commands.executeCommand("weAudit.clearDocOverlay");
+            }
+        }
+    }
+
+    private _buildHtml(): string {
+        const state = this.getState();
+        const nonce = crypto.randomBytes(16).toString("base64");
+        const csp = [`default-src 'none'`, `style-src 'unsafe-inline'`, `script-src 'nonce-${nonce}'`].join("; ");
+
+        const esc = (s: string): string => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+        // Bake the full log history into the initial HTML so it's visible immediately on reopen.
+        const logHtml = state.log.map((e) => `<div class="log-entry log-${e.type}">${esc(e.text)}</div>`).join("");
+
+        return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="${csp}">
+  <title>Docs Overlay</title>
+  <style>
+    body {
+      padding: 8px 12px;
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-foreground);
+      background: var(--vscode-sideBar-background);
+    }
+    label {
+      display: block;
+      margin-top: 10px;
+      margin-bottom: 2px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--vscode-descriptionForeground);
+    }
+    .row {
+      display: flex;
+      gap: 4px;
+    }
+    input[type="text"] {
+      flex: 1;
+      min-width: 0;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, transparent);
+      padding: 3px 6px;
+      font-family: inherit;
+      font-size: inherit;
+      outline: none;
+    }
+    input[type="text"]:focus {
+      border-color: var(--vscode-focusBorder);
+    }
+    button {
+      background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+      color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+      border: none;
+      padding: 6px 8px;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: inherit;
+      box-sizing: border-box;
+    }
+    button:hover {
+      background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+    }
+    #generate {
+      display: block;
+      width: 100%;
+      margin-top: 14px;
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    #generate:hover {
+      background: var(--vscode-button-hoverBackground);
+    }
+    .actions {
+      display: flex;
+      gap: 6px;
+      margin-top: 6px;
+    }
+    .actions button {
+      flex: 1;
+    }
+    #toggle-overlay.overlay-visible:not(:disabled) {
+      background: #1a9c7a;
+      color: #ffffff;
+    }
+    #toggle-overlay.overlay-visible:not(:disabled):hover {
+      background: #1db88f;
+    }
+    #toggle-overlay.overlay-hidden:not(:disabled) {
+      background: #4a5057;
+      color: #9a9da2;
+    }
+    #toggle-overlay.overlay-hidden:not(:disabled):hover {
+      background: #565c64;
+    }
+    #clear-docs:not(:disabled) {
+      background: #a42b1c;
+      color: #ffffff;
+    }
+    #clear-docs:not(:disabled):hover {
+      background: #c0321f;
+    }
+    #clear-docs:disabled:hover,
+    #toggle-overlay:disabled:hover {
+      background: #4a5057;
+    }
+    #clear-docs:disabled,
+    #toggle-overlay:disabled {
+      background: #4a5057;
+      color: #9a9da2;
+      cursor: not-allowed;
+    }
+    #log {
+      margin-top: 12px;
+      max-height: 340px;
+      overflow-y: auto;
+      border: 1px solid var(--vscode-widget-border, transparent);
+      background: var(--vscode-editor-background);
+      padding: 6px 8px;
+      box-sizing: border-box;
+    }
+    #log:empty {
+      display: none;
+    }
+    .log-entry {
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-size: 11px;
+      line-height: 1.5;
+      padding: 3px 0;
+      border-bottom: 1px solid var(--vscode-widget-border, transparent);
+    }
+    .log-entry:last-child {
+      border-bottom: none;
+    }
+    .log-info {
+      color: var(--vscode-descriptionForeground);
+    }
+    .log-assistant {
+      color: var(--vscode-foreground);
+      font-family: var(--vscode-editor-font-family, monospace);
+    }
+    .log-error {
+      color: var(--vscode-errorForeground, #f44);
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <label for="claudeBinaryPath">Claude Binary</label>
+  <div class="row">
+    <input id="claudeBinaryPath" type="text" placeholder="/path/to/claude" value="${esc(state.claudeBinaryPath)}">
+  </div>
+
+  <label for="skillName">Skill Name</label>
+  <div class="row">
+    <input id="skillName" type="text" placeholder="my-skill" value="${esc(state.skillName)}">
+  </div>
+
+  <label for="pluginDir">Plugin Directory</label>
+  <div class="row">
+    <input id="pluginDir" type="text" placeholder="/path/to/plugin" value="${esc(state.pluginDir)}">
+    <button data-field="pluginDir">…</button>
+  </div>
+
+  <label for="targetDir">Target Directory</label>
+  <div class="row">
+    <input id="targetDir" type="text" placeholder="/path/to/target" value="${esc(state.targetDir)}">
+    <button data-field="targetDir">…</button>
+  </div>
+
+  <button id="generate">Generate Docs</button>
+  <div class="actions">
+    <button id="toggle-overlay" class="${state.overlayVisible ? "overlay-visible" : "overlay-hidden"}" ${state.hasDocs ? "" : "disabled"}>Toggle Overlay</button>
+    <button id="clear-docs" ${state.hasDocs ? "" : "disabled"}>Clear Docs</button>
+  </div>
+  <div id="log">${logHtml}</div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const log = document.getElementById('log');
+
+    function appendEntry(type, text) {
+      const el = document.createElement('div');
+      el.className = 'log-entry log-' + type;
+      el.textContent = text;
+      log.appendChild(el);
+      log.scrollTop = log.scrollHeight;
+    }
+
+    // Scroll to bottom on initial load so the latest entry is visible.
+    log.scrollTop = log.scrollHeight;
+
+    document.querySelectorAll('button[data-field]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        vscode.postMessage({ command: 'browse', field: btn.dataset.field });
+      });
+    });
+
+    document.getElementById('generate').addEventListener('click', () => {
+      vscode.postMessage({
+        command: 'generate',
+        claudeBinaryPath: document.getElementById('claudeBinaryPath').value.trim(),
+        pluginDir: document.getElementById('pluginDir').value.trim(),
+        skillName: document.getElementById('skillName').value.trim(),
+        targetDir: document.getElementById('targetDir').value.trim(),
+      });
+    });
+
+    document.getElementById('toggle-overlay').addEventListener('click', () => {
+      vscode.postMessage({ command: 'toggle-overlay' });
+    });
+
+    document.getElementById('clear-docs').addEventListener('click', () => {
+      vscode.postMessage({ command: 'clear-docs' });
+    });
+
+    window.addEventListener('message', ({ data }) => {
+      if (data.command === 'set-field') {
+        document.getElementById(data.field).value = data.value;
+      } else if (data.command === 'append-log') {
+        appendEntry(data.logType, data.text);
+      } else if (data.command === 'sync-state') {
+        const toggleBtn = document.getElementById('toggle-overlay');
+        toggleBtn.className = data.overlayVisible ? 'overlay-visible' : 'overlay-hidden';
+        toggleBtn.disabled = !data.hasDocs;
+        const clearBtn = document.getElementById('clear-docs');
+        clearBtn.disabled = !data.hasDocs;
+      }
+    });
+  </script>
+</body>
+</html>`;
+    }
+}

--- a/src/docOverlay/docStore.ts
+++ b/src/docOverlay/docStore.ts
@@ -1,0 +1,134 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import type * as vscode from "vscode";
+
+import { type DocEntry, type DocSessionData, isValidDocEntry } from "./types";
+
+const DOCS_DIR = "weaudit-docs";
+
+/**
+ * Persists and retrieves documentation sessions from <workspaceRoot>/weaudit-docs/.
+ * Each session is a subdirectory containing metadata.json and entries.json.
+ */
+export class DocStore {
+    private readonly docsDir: string;
+
+    /** @param workspaceRoot Absolute path to the workspace root. */
+    constructor(private readonly workspaceRoot: string) {
+        this.docsDir = path.join(workspaceRoot, DOCS_DIR);
+    }
+
+    /**
+     * Reads all valid sessions from the weaudit-docs/ directory.
+     * Silently skips sessions with missing or malformed JSON files.
+     * @returns Array of loaded DocSessionData objects.
+     */
+    loadAllSessions(): DocSessionData[] {
+        if (!fs.existsSync(this.docsDir)) {
+            return [];
+        }
+
+        const sessions: DocSessionData[] = [];
+
+        for (const sessionDir of safeReadDir(this.docsDir)) {
+            const sessionPath = path.join(this.docsDir, sessionDir);
+            let stat: fs.Stats;
+            try {
+                stat = fs.statSync(sessionPath);
+            } catch {
+                continue;
+            }
+            if (!stat.isDirectory()) {
+                continue;
+            }
+
+            const metaPath = path.join(sessionPath, "metadata.json");
+            const entriesPath = path.join(sessionPath, "entries.json");
+
+            try {
+                const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8")) as Record<string, unknown>;
+                const entriesRaw = JSON.parse(fs.readFileSync(entriesPath, "utf-8")) as unknown[];
+
+                const entries = entriesRaw.filter((e): e is DocEntry => {
+                    const valid = isValidDocEntry(e);
+                    if (!valid) {
+                        console.warn(`weAudit docOverlay: skipping invalid entry in ${entriesPath}`);
+                    }
+                    return valid;
+                });
+
+                sessions.push({
+                    version: 1,
+                    skill: stringField(meta["skill"]),
+                    targetDirectory: stringField(meta["targetDirectory"]),
+                    generatedAt: stringField(meta["generatedAt"]),
+                    workspaceRoot: stringField(meta["workspaceRoot"]) || this.workspaceRoot,
+                    entries,
+                });
+            } catch {
+                console.warn(`weAudit docOverlay: skipping corrupted session at ${sessionPath}`);
+            }
+        }
+
+        return sessions;
+    }
+
+    /**
+     * Writes a documentation session to disk under a directory named after the target.
+     * If a session for the same target directory already exists it is overwritten,
+     * so there is always at most one session per target directory.
+     * @param data The session data to persist.
+     * @returns The absolute path to the session directory.
+     */
+    persistSession(data: DocSessionData): string {
+        const slug = data.targetDirectory.replace(/[^a-zA-Z0-9_-]/g, "_");
+        const sessionDir = path.join(this.docsDir, slug);
+        fs.mkdirSync(sessionDir, { recursive: true });
+
+        const { entries, ...meta } = data;
+        fs.writeFileSync(path.join(sessionDir, "metadata.json"), JSON.stringify(meta, null, 2), "utf-8");
+        fs.writeFileSync(path.join(sessionDir, "entries.json"), JSON.stringify(entries, null, 2), "utf-8");
+
+        return sessionDir;
+    }
+
+    /**
+     * Deletes the entire weaudit-docs/ directory and all its sessions.
+     */
+    clearAllSessions(): void {
+        if (fs.existsSync(this.docsDir)) {
+            fs.rmSync(this.docsDir, { recursive: true, force: true });
+        }
+    }
+
+    /**
+     * Watches weaudit-docs/** for external file system changes.
+     * @param cb Callback invoked on any create, change, or delete event.
+     * @returns A disposable that stops the watcher when disposed.
+     */
+    watchForChanges(cb: () => void): vscode.Disposable {
+        // Lazy-require vscode so this module remains loadable outside a VS Code host (unit tests).
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const vscodeModule = require("vscode") as typeof vscode;
+        const pattern = new vscodeModule.RelativePattern(this.workspaceRoot, `${DOCS_DIR}/**`);
+        const watcher = vscodeModule.workspace.createFileSystemWatcher(pattern);
+        watcher.onDidCreate(cb);
+        watcher.onDidChange(cb);
+        watcher.onDidDelete(cb);
+        return watcher;
+    }
+}
+
+/** Safely extracts a string field from an unknown metadata record value. */
+function stringField(value: unknown): string {
+    return typeof value === "string" ? value : "";
+}
+
+function safeReadDir(dir: string): string[] {
+    try {
+        return fs.readdirSync(dir);
+    } catch {
+        return [];
+    }
+}

--- a/src/docOverlay/hoverProvider.ts
+++ b/src/docOverlay/hoverProvider.ts
@@ -31,7 +31,14 @@ export class DocOverlayHoverProvider {
 
         const matching = this.getEntries().filter((entry) => {
             const entryPath = resolveEntryPath(entry.path, this.workspaceRoot);
-            return entryPath === filePath && line >= entry.startLine && line <= entry.endLine;
+            if (entryPath !== filePath) {
+                return false;
+            }
+            // File-level entries are pinned to the first line only.
+            if (entry.type === "file") {
+                return line === 0;
+            }
+            return line >= entry.startLine && line <= entry.endLine;
         });
 
         if (matching.length === 0) {

--- a/src/docOverlay/hoverProvider.ts
+++ b/src/docOverlay/hoverProvider.ts
@@ -1,0 +1,65 @@
+import * as path from "path";
+
+import type * as vscode from "vscode";
+
+import type { DocEntry } from "./types";
+
+/**
+ * Provides hover tooltips showing full markdown documentation for annotated code regions.
+ * Registered for all file-scheme documents; only activates when a doc entry covers the cursor.
+ */
+export class DocOverlayHoverProvider {
+    /**
+     * @param getEntries Lazy getter returning the current set of loaded doc entries.
+     * @param workspaceRoot Absolute workspace root for resolving relative entry paths.
+     */
+    constructor(
+        private readonly getEntries: () => DocEntry[],
+        private readonly workspaceRoot: string,
+    ) {}
+
+    /**
+     * Returns hover content when the cursor falls within a documented region.
+     * Multiple overlapping entries are rendered as sections separated by horizontal rules.
+     * @param document The document in which the hover was triggered.
+     * @param position The position at which the hover was triggered.
+     * @returns A Hover with full markdown, or undefined if no entry covers the position.
+     */
+    provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | undefined {
+        const filePath = document.uri.fsPath;
+        const line = position.line;
+
+        const matching = this.getEntries().filter((entry) => {
+            const entryPath = resolveEntryPath(entry.path, this.workspaceRoot);
+            return entryPath === filePath && line >= entry.startLine && line <= entry.endLine;
+        });
+
+        if (matching.length === 0) {
+            return undefined;
+        }
+
+        // Lazy-require vscode so the class is instantiable outside a VS Code host.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const vscodeModule = require("vscode") as typeof vscode;
+
+        const md = new vscodeModule.MarkdownString();
+        md.isTrusted = true;
+        md.supportHtml = false;
+
+        for (const entry of matching) {
+            const header = entry.functionName ?? (entry.type === "file" ? "File" : "Region");
+            md.appendMarkdown(`### ${header}\n\n`);
+            md.appendMarkdown(entry.fullDoc);
+            md.appendMarkdown("\n\n---\n\n");
+        }
+
+        return new vscodeModule.Hover(md);
+    }
+}
+
+function resolveEntryPath(entryRelPath: string, workspaceRoot: string): string {
+    if (path.isAbsolute(entryRelPath)) {
+        return entryRelPath;
+    }
+    return path.resolve(workspaceRoot, entryRelPath);
+}

--- a/src/docOverlay/types.ts
+++ b/src/docOverlay/types.ts
@@ -1,0 +1,68 @@
+/** Entry type: function, file-level, or region. */
+export type DocEntryType = "function" | "file" | "region";
+
+/**
+ * A single documented symbol or code region produced by the documentation agent.
+ * Persisted to disk and loaded back to drive editor decorations and hover tooltips.
+ */
+export interface DocEntry {
+    type: DocEntryType;
+    /** Relative path from workspace root. */
+    path: string;
+    /** 0-indexed start line. */
+    startLine: number;
+    /** 0-indexed end line, inclusive. */
+    endLine: number;
+    /** Function name, present when type === "function". */
+    functionName?: string;
+    /** 1–2 sentence summary shown as inline ghost text. */
+    summary: string;
+    /** Full markdown documentation shown in hover tooltip. */
+    fullDoc: string;
+    /** ISO 8601 generation timestamp. */
+    generatedAt: string;
+    /** Skill name (stem of .md file). */
+    skill: string;
+}
+
+/**
+ * Persisted metadata for one documentation generation run.
+ * Split across metadata.json (all fields except entries) and entries.json.
+ */
+export interface DocSessionData {
+    version: 1;
+    skill: string;
+    /** Relative path from workspace root. */
+    targetDirectory: string;
+    generatedAt: string;
+    workspaceRoot: string;
+    entries: DocEntry[];
+}
+
+/**
+ * Validates that an unknown value conforms to the DocEntry interface.
+ * Used when deserializing agent responses and stored sessions.
+ * @param obj The value to validate.
+ * @returns True if the value is a valid DocEntry, false otherwise.
+ */
+export function isValidDocEntry(obj: unknown): obj is DocEntry {
+    if (typeof obj !== "object" || obj === null) {
+        return false;
+    }
+    const e = obj as Record<string, unknown>;
+    return (
+        (e["type"] === "function" || e["type"] === "file" || e["type"] === "region") &&
+        typeof e["path"] === "string" &&
+        e["path"].length > 0 &&
+        typeof e["startLine"] === "number" &&
+        typeof e["endLine"] === "number" &&
+        e["startLine"] >= 0 &&
+        e["endLine"] >= e["startLine"] &&
+        typeof e["summary"] === "string" &&
+        e["summary"].length > 0 &&
+        typeof e["fullDoc"] === "string" &&
+        typeof e["generatedAt"] === "string" &&
+        typeof e["skill"] === "string" &&
+        (e["functionName"] === undefined || typeof e["functionName"] === "string")
+    );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import * as vscode from "vscode";
 
 import { AuditMarker } from "./codeMarker";
+import { DocOverlayManager } from "./docOverlay/docOverlayManager";
 import { MultipleSavedFindings } from "./multiConfigs";
 import { activateFindingDetailsWebview } from "./panels/findingDetailsPanel";
 import { activateGitConfigWebview } from "./panels/gitConfigPanel";
@@ -23,6 +24,7 @@ export function activate(context: vscode.ExtensionContext): void {
     new MultipleSavedFindings(context);
     activateFindingDetailsWebview(context);
     activateGitConfigWebview(context);
+    new DocOverlayManager(context);
 }
 
 async function openResource(resource: vscode.Uri, startLine: number, endLine: number): Promise<void> {

--- a/test/unit/docOverlay.test.ts
+++ b/test/unit/docOverlay.test.ts
@@ -1,0 +1,591 @@
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { buildDocDecorations } from "../../src/docOverlay/decorations";
+import { DocStore } from "../../src/docOverlay/docStore";
+import { buildPrompt, detectClaudeBinary, parseEntries } from "../../src/docOverlay/agentRunner";
+import { DocOverlayHoverProvider } from "../../src/docOverlay/hoverProvider";
+import { isValidDocEntry } from "../../src/docOverlay/types";
+import type { DocEntry, DocSessionData } from "../../src/docOverlay/types";
+
+// ---------------------------------------------------------------------------
+// Minimal VS Code mock
+// Intercepts lazy require("vscode") calls that happen inside production code
+// running outside a VS Code host (e.g. parseEntries warnings, hoverProvider).
+// ---------------------------------------------------------------------------
+
+const fakeVscode = {
+    window: {
+        showWarningMessage: (..._args: unknown[]) => Promise.resolve(undefined),
+        showErrorMessage: (..._args: unknown[]) => Promise.resolve(undefined),
+    },
+    workspace: {
+        getConfiguration: (_section: string) => ({
+            get: (_key: string, defaultValue: unknown) => defaultValue,
+        }),
+    },
+    MarkdownString: class {
+        isTrusted = false;
+        supportHtml = false;
+        value = "";
+        appendMarkdown(s: string): this {
+            this.value += s;
+            return this;
+        }
+    },
+    Hover: class {
+        constructor(public contents: unknown) {}
+    },
+};
+
+// Install the mock before any tests run so all lazy require("vscode") calls
+// in production code return fakeVscode instead of throwing.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const NodeModule = require("module") as { _load: (...args: unknown[]) => unknown };
+const _originalLoad = NodeModule._load.bind(NodeModule);
+NodeModule._load = function (request: string, ...args: unknown[]): unknown {
+    if (request === "vscode") return fakeVscode;
+    return _originalLoad(request, ...args);
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<DocEntry> = {}): DocEntry {
+    return {
+        type: "function",
+        path: "src/foo.ts",
+        startLine: 0,
+        endLine: 5,
+        functionName: "myFunc",
+        summary: "Does something useful.",
+        fullDoc: "## myFunc\n\nDoes something.",
+        generatedAt: new Date().toISOString(),
+        skill: "test-skill",
+        ...overrides,
+    };
+}
+
+function makeSessionData(entries: DocEntry[] = []): DocSessionData {
+    return {
+        version: 1,
+        skill: "test-skill",
+        targetDirectory: "src",
+        generatedAt: new Date().toISOString(),
+        workspaceRoot: "/tmp/ws",
+        entries,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// isValidDocEntry
+// ---------------------------------------------------------------------------
+
+describe("isValidDocEntry", () => {
+    it("accepts a fully valid function entry", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry()), true);
+    });
+
+    it("accepts a file-type entry without functionName", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ type: "file", functionName: undefined })), true);
+    });
+
+    it("accepts a region entry", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ type: "region", functionName: undefined })), true);
+    });
+
+    it("rejects null", () => {
+        assert.strictEqual(isValidDocEntry(null), false);
+    });
+
+    it("rejects non-object", () => {
+        assert.strictEqual(isValidDocEntry("string"), false);
+        assert.strictEqual(isValidDocEntry(42), false);
+    });
+
+    it("rejects missing path", () => {
+        const e = makeEntry() as unknown as Record<string, unknown>;
+        delete e["path"];
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects empty path", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ path: "" })), false);
+    });
+
+    it("rejects invalid type", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ type: "module" as DocEntry["type"] })), false);
+    });
+
+    it("rejects negative startLine", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ startLine: -1 })), false);
+    });
+
+    it("rejects endLine < startLine", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ startLine: 10, endLine: 5 })), false);
+    });
+
+    it("rejects missing summary", () => {
+        const e = makeEntry() as unknown as Record<string, unknown>;
+        delete e["summary"];
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects empty summary", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ summary: "" })), false);
+    });
+
+    it("rejects missing fullDoc", () => {
+        const e = makeEntry() as unknown as Record<string, unknown>;
+        delete e["fullDoc"];
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects numeric functionName", () => {
+        const e = { ...makeEntry(), functionName: 123 } as unknown;
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("accepts undefined functionName", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ functionName: undefined })), true);
+    });
+
+    it("accepts string functionName", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ functionName: "foo" })), true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// DocStore — persist / load round-trip (fs-only, no VS Code host needed)
+// ---------------------------------------------------------------------------
+
+describe("DocStore", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "weaudit-docstore-test-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns empty array when weaudit-docs/ does not exist", () => {
+        const store = new DocStore(tmpDir);
+        const sessions = store.loadAllSessions();
+        assert.deepStrictEqual(sessions, []);
+    });
+
+    it("round-trips a session through persistSession / loadAllSessions", () => {
+        const store = new DocStore(tmpDir);
+        const entry = makeEntry({ path: "src/hello.ts" });
+        const data = makeSessionData([entry]);
+        data.workspaceRoot = tmpDir;
+
+        store.persistSession(data);
+        const loaded = store.loadAllSessions();
+
+        assert.strictEqual(loaded.length, 1);
+        assert.strictEqual(loaded[0]?.skill, "test-skill");
+        assert.strictEqual(loaded[0]?.entries.length, 1);
+        assert.strictEqual(loaded[0]?.entries[0]?.path, "src/hello.ts");
+    });
+
+    it("persists sessions for different targets and loads all of them", () => {
+        const store = new DocStore(tmpDir);
+        const dataA = makeSessionData([makeEntry({ path: "a.ts" })]);
+        dataA.targetDirectory = "src/moduleA";
+        const dataB = makeSessionData([makeEntry({ path: "b.ts" })]);
+        dataB.targetDirectory = "src/moduleB";
+        store.persistSession(dataA);
+        store.persistSession(dataB);
+
+        const loaded = store.loadAllSessions();
+        assert.strictEqual(loaded.length, 2);
+    });
+
+    it("overwrites an existing session when persisting the same target directory", () => {
+        const store = new DocStore(tmpDir);
+        const first = makeSessionData([makeEntry({ path: "old.ts" })]);
+        const second = makeSessionData([makeEntry({ path: "new.ts" })]);
+
+        store.persistSession(first);
+        store.persistSession(second);
+
+        const loaded = store.loadAllSessions();
+        assert.strictEqual(loaded.length, 1);
+        assert.strictEqual(loaded[0]?.entries[0]?.path, "new.ts");
+    });
+
+    it("clearAllSessions removes the weaudit-docs directory", () => {
+        const store = new DocStore(tmpDir);
+        store.persistSession(makeSessionData([makeEntry()]));
+
+        const docsDir = path.join(tmpDir, "weaudit-docs");
+        assert.ok(fs.existsSync(docsDir), "weaudit-docs should exist before clear");
+
+        store.clearAllSessions();
+        assert.ok(!fs.existsSync(docsDir), "weaudit-docs should be gone after clear");
+    });
+
+    it("clearAllSessions is a no-op when weaudit-docs/ does not exist", () => {
+        const store = new DocStore(tmpDir);
+        // Should not throw.
+        store.clearAllSessions();
+    });
+
+    it("skips corrupted sessions without throwing", () => {
+        const store = new DocStore(tmpDir);
+        // Write a valid session first.
+        store.persistSession(makeSessionData([makeEntry()]));
+
+        // Write a corrupted session directory.
+        const badDir = path.join(tmpDir, "weaudit-docs", "bad-session");
+        fs.mkdirSync(badDir, { recursive: true });
+        fs.writeFileSync(path.join(badDir, "metadata.json"), "not json");
+        fs.writeFileSync(path.join(badDir, "entries.json"), "not json");
+
+        const loaded = store.loadAllSessions();
+        // Only the valid session should be loaded.
+        assert.strictEqual(loaded.length, 1);
+    });
+
+    it("skips invalid entries within a valid session", () => {
+        const store = new DocStore(tmpDir);
+        const sessionDir = store.persistSession(makeSessionData([makeEntry()]));
+
+        // Overwrite entries.json with one valid and one invalid entry.
+        const entriesPath = path.join(sessionDir, "entries.json");
+        const invalid = { type: "function" }; // missing required fields
+        fs.writeFileSync(entriesPath, JSON.stringify([makeEntry({ path: "good.ts" }), invalid]), "utf-8");
+
+        const loaded = store.loadAllSessions();
+        assert.strictEqual(loaded[0]?.entries.length, 1);
+        assert.strictEqual(loaded[0]?.entries[0]?.path, "good.ts");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildDocDecorations (pure structure check — no VS Code runtime needed)
+// ---------------------------------------------------------------------------
+
+describe("buildDocDecorations", () => {
+    const workspaceRoot = "/workspace";
+
+    it("returns empty array when no entries match the file", () => {
+        const entries: DocEntry[] = [makeEntry({ path: "src/other.ts" })];
+        const result = buildDocDecorations(entries, "/workspace/src/main.ts", workspaceRoot);
+        assert.strictEqual(result.length, 0);
+    });
+
+    it("returns one decoration per matching entry", () => {
+        const entries: DocEntry[] = [
+            makeEntry({ path: "src/main.ts", startLine: 0 }),
+            makeEntry({ path: "src/main.ts", startLine: 10 }),
+            makeEntry({ path: "src/other.ts", startLine: 5 }),
+        ];
+        const result = buildDocDecorations(entries, "/workspace/src/main.ts", workspaceRoot);
+        assert.strictEqual(result.length, 2);
+    });
+
+    it("sets the decoration range to the entry startLine", () => {
+        const entry = makeEntry({ path: "src/main.ts", startLine: 7 });
+        const result = buildDocDecorations([entry], "/workspace/src/main.ts", workspaceRoot);
+        assert.strictEqual(result.length, 1);
+        // The range is a plain object with start/end because we avoid new vscode.Range in unit-test context.
+        const range = result[0]?.range as unknown as { start: { line: number } };
+        assert.strictEqual(range.start.line, 7);
+    });
+
+    it("includes functionName in ghost text when present", () => {
+        const entry = makeEntry({ path: "src/main.ts", functionName: "doWork", summary: "Works." });
+        const result = buildDocDecorations([entry], "/workspace/src/main.ts", workspaceRoot);
+        const opts = result[0] as { renderOptions?: { dark?: { after?: { contentText?: string } } } };
+        const contentText = opts.renderOptions?.dark?.after?.contentText ?? "";
+        assert.ok(contentText.includes("doWork"), `Expected "doWork" in "${contentText}"`);
+    });
+
+    it("shows only summary when functionName is absent", () => {
+        const entry = makeEntry({ path: "src/main.ts", functionName: undefined, summary: "Just a region." });
+        const result = buildDocDecorations([entry], "/workspace/src/main.ts", workspaceRoot);
+        const opts = result[0] as { renderOptions?: { dark?: { after?: { contentText?: string } } } };
+        const contentText = opts.renderOptions?.dark?.after?.contentText ?? "";
+        assert.ok(contentText.includes("Just\u00a0a\u00a0region"), `Expected summary in "${contentText}"`);
+    });
+
+    it("resolves absolute entry paths", () => {
+        const entry = makeEntry({ path: "/workspace/src/main.ts" });
+        const result = buildDocDecorations([entry], "/workspace/src/main.ts", workspaceRoot);
+        assert.strictEqual(result.length, 1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// isValidDocEntry — additional edge cases
+// ---------------------------------------------------------------------------
+
+describe("isValidDocEntry — additional edge cases", () => {
+    it("rejects missing generatedAt", () => {
+        const e = makeEntry() as unknown as Record<string, unknown>;
+        delete e["generatedAt"];
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects non-string generatedAt", () => {
+        const e = { ...makeEntry(), generatedAt: 12345 } as unknown;
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects missing skill", () => {
+        const e = makeEntry() as unknown as Record<string, unknown>;
+        delete e["skill"];
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects non-string skill", () => {
+        const e = { ...makeEntry(), skill: true } as unknown;
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("rejects non-string fullDoc", () => {
+        const e = { ...makeEntry(), fullDoc: [] } as unknown;
+        assert.strictEqual(isValidDocEntry(e), false);
+    });
+
+    it("accepts equal startLine and endLine (single-line entry)", () => {
+        assert.strictEqual(isValidDocEntry(makeEntry({ startLine: 5, endLine: 5 })), true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseEntries — JSON extraction and validation
+// ---------------------------------------------------------------------------
+
+describe("parseEntries", () => {
+    it("returns empty array when response contains no JSON array", () => {
+        const result = parseEntries("No JSON here.");
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("returns empty array when JSON array is malformed", () => {
+        const result = parseEntries("[{broken json}]");
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("returns validated entries from a well-formed JSON array", () => {
+        const entry = makeEntry({ path: "src/parsed.ts" });
+        const result = parseEntries(JSON.stringify([entry]));
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0]?.path, "src/parsed.ts");
+    });
+
+    it("filters out invalid entries and keeps valid ones", () => {
+        const valid = makeEntry({ path: "src/good.ts" });
+        const invalid = { type: "function" }; // missing required fields
+        const result = parseEntries(JSON.stringify([valid, invalid]));
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0]?.path, "src/good.ts");
+    });
+
+    it("extracts JSON array even when surrounded by extra text", () => {
+        const entry = makeEntry({ path: "src/surrounded.ts" });
+        const response = `Here is the output:\n${JSON.stringify([entry])}\nEnd of output.`;
+        const result = parseEntries(response);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0]?.path, "src/surrounded.ts");
+    });
+
+    it("returns empty array for an empty JSON array", () => {
+        const result = parseEntries("[]");
+        assert.deepStrictEqual(result, []);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildPrompt — prompt structure
+// ---------------------------------------------------------------------------
+
+describe("buildPrompt", () => {
+    const skillName = "my-skill";
+    const targetDir = "/repo/src/module";
+    const workspaceRoot = "/repo";
+
+    it("starts with the skill slash-command", () => {
+        const prompt = buildPrompt(skillName, targetDir, workspaceRoot);
+        assert.ok(prompt.startsWith(`/${skillName} `), `Expected prompt to start with /${skillName}`);
+    });
+
+    it("contains the target directory", () => {
+        const prompt = buildPrompt(skillName, targetDir, workspaceRoot);
+        assert.ok(prompt.includes(targetDir), "Expected prompt to include targetDir");
+    });
+
+    it("contains the workspace root", () => {
+        const prompt = buildPrompt(skillName, targetDir, workspaceRoot);
+        assert.ok(prompt.includes(workspaceRoot), "Expected prompt to include workspaceRoot");
+    });
+
+    it("contains the JSON schema fields", () => {
+        const prompt = buildPrompt(skillName, targetDir, workspaceRoot);
+        for (const field of ["type", "path", "startLine", "endLine", "summary", "fullDoc", "generatedAt", "skill"]) {
+            assert.ok(prompt.includes(`"${field}"`), `Expected prompt to include schema field "${field}"`);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// detectClaudeBinary — binary location detection
+// ---------------------------------------------------------------------------
+
+describe("detectClaudeBinary", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "weaudit-bin-test-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns the CLAUDE_BINARY env var path when the file exists", () => {
+        const binPath = path.join(tmpDir, "claude");
+        fs.writeFileSync(binPath, "");
+        const original = process.env["CLAUDE_BINARY"];
+        process.env["CLAUDE_BINARY"] = binPath;
+        try {
+            assert.strictEqual(detectClaudeBinary(), binPath);
+        } finally {
+            if (original === undefined) delete process.env["CLAUDE_BINARY"];
+            else process.env["CLAUDE_BINARY"] = original;
+        }
+    });
+
+    it("does not return CLAUDE_BINARY path when it does not exist on disk", () => {
+        const nonExistentPath = path.join(tmpDir, "nonexistent-claude");
+        const original = process.env["CLAUDE_BINARY"];
+        process.env["CLAUDE_BINARY"] = nonExistentPath;
+        try {
+            const result = detectClaudeBinary();
+            assert.notStrictEqual(result, nonExistentPath);
+        } finally {
+            if (original === undefined) delete process.env["CLAUDE_BINARY"];
+            else process.env["CLAUDE_BINARY"] = original;
+        }
+    });
+
+    it("always returns a string", () => {
+        const original = process.env["CLAUDE_BINARY"];
+        delete process.env["CLAUDE_BINARY"];
+        try {
+            assert.strictEqual(typeof detectClaudeBinary(), "string");
+        } finally {
+            if (original !== undefined) process.env["CLAUDE_BINARY"] = original;
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// DocOverlayHoverProvider — entry matching and hover content
+// ---------------------------------------------------------------------------
+
+describe("DocOverlayHoverProvider", () => {
+    const workspaceRoot = "/workspace";
+
+    /** Minimal vscode.TextDocument stub. */
+    function makeDoc(fsPath: string) {
+        return { uri: { fsPath } };
+    }
+
+    /** Minimal vscode.Position stub. */
+    function makePos(line: number) {
+        return { line };
+    }
+
+    it("returns undefined when the entries list is empty", () => {
+        const provider = new DocOverlayHoverProvider(() => [], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(3) as never);
+        assert.strictEqual(result, undefined);
+    });
+
+    it("returns undefined when entries exist for a different file", () => {
+        const provider = new DocOverlayHoverProvider(() => [makeEntry({ path: "src/other.ts" })], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(0) as never);
+        assert.strictEqual(result, undefined);
+    });
+
+    it("returns undefined when cursor line is before the entry startLine", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 10, endLine: 20 });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(9) as never);
+        assert.strictEqual(result, undefined);
+    });
+
+    it("returns undefined when cursor line is after the entry endLine", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 10, endLine: 20 });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(21) as never);
+        assert.strictEqual(result, undefined);
+    });
+
+    it("returns a hover when cursor is on the startLine", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 5, endLine: 15 });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(5) as never);
+        assert.ok(result !== undefined, "Expected a hover");
+    });
+
+    it("returns a hover when cursor is on the endLine", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 5, endLine: 15 });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(15) as never);
+        assert.ok(result !== undefined, "Expected a hover");
+    });
+
+    it("includes fullDoc content from all matching entries", () => {
+        const entries = [
+            makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 10, fullDoc: "Doc for alpha." }),
+            makeEntry({ path: "src/foo.ts", startLine: 5, endLine: 15, fullDoc: "Doc for beta." }),
+        ];
+        const provider = new DocOverlayHoverProvider(() => entries, workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(7) as never);
+        assert.ok(result !== undefined, "Expected a hover");
+        const md = (result as { contents: { value: string } }).contents;
+        assert.ok(md.value.includes("Doc for alpha."), "Expected first entry fullDoc in hover");
+        assert.ok(md.value.includes("Doc for beta."), "Expected second entry fullDoc in hover");
+    });
+
+    it("uses functionName as the section header when present", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 5, functionName: "myFunc" });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(2) as never);
+        const md = (result as { contents: { value: string } }).contents;
+        assert.ok(md.value.includes("### myFunc"), `Expected "### myFunc" header in hover`);
+    });
+
+    it('uses "File" as header for file entries without functionName', () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 5, type: "file", functionName: undefined });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(2) as never);
+        const md = (result as { contents: { value: string } }).contents;
+        assert.ok(md.value.includes("### File"), `Expected "### File" header in hover`);
+    });
+
+    it('uses "Region" as header for region entries without functionName', () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 5, type: "region", functionName: undefined });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(2) as never);
+        const md = (result as { contents: { value: string } }).contents;
+        assert.ok(md.value.includes("### Region"), `Expected "### Region" header in hover`);
+    });
+
+    it("resolves absolute entry paths", () => {
+        const entry = makeEntry({ path: "/workspace/src/foo.ts", startLine: 0, endLine: 5 });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(2) as never);
+        assert.ok(result !== undefined, "Expected a hover for absolute path entry");
+    });
+});

--- a/test/unit/docOverlay.test.ts
+++ b/test/unit/docOverlay.test.ts
@@ -559,9 +559,17 @@ describe("DocOverlayHoverProvider", () => {
     it('uses "File" as header for file entries without functionName', () => {
         const entry = makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 5, type: "file", functionName: undefined });
         const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
-        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(2) as never);
+        const result = provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(0) as never);
         const md = (result as { contents: { value: string } }).contents;
         assert.ok(md.value.includes("### File"), `Expected "### File" header in hover`);
+    });
+
+    it("file entries only show a hover on line 0", () => {
+        const entry = makeEntry({ path: "src/foo.ts", startLine: 0, endLine: 100, type: "file", functionName: undefined });
+        const provider = new DocOverlayHoverProvider(() => [entry], workspaceRoot);
+        assert.ok(provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(0) as never) !== undefined, "Expected hover on line 0");
+        assert.strictEqual(provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(1) as never), undefined, "Expected no hover on line 1");
+        assert.strictEqual(provider.provideHover(makeDoc("/workspace/src/foo.ts") as never, makePos(50) as never), undefined, "Expected no hover on line 50");
     });
 
     it('uses "Region" as header for region entries without functionName', () => {


### PR DESCRIPTION
# Docs Overlay — AI-generated inline documentation for code review

## What it does

The Docs Overlay feature adds AI-generated ghost-text annotations directly inside your editors.
When you open a file that has been documented, each function or region shows a one-line summary
as dimmed text above the declaration and a full markdown document on hover — without modifying
the source file.

The feature is designed for security audits and deep code reviews, where quickly understanding
unfamiliar functions saves time. You point the agent at a directory, choose a Claude skill that
knows how to analyze the codebase, and the agent autonomously reads every source file and
produces structured documentation. Results are saved to `weaudit-docs/` inside the workspace
so they survive restarts and can be shared with teammates.

## How to use it

### 1. Prerequisites

| Requirement | How to get it |
|-------------|---------------|
| Claude CLI (`claude`) | Install from the [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) |
| Anthropic API key | Create one at [console.anthropic.com](https://console.anthropic.com) |
| A Claude skill plugin | A local plugin directory containing a skill (see below) |

### 2. Configure the API key

Open VS Code settings and set:

```
weAudit › Doc Overlay › Anthropic API Key
```

The key is stored in VS Code's settings (user or workspace scope — your choice). It is passed
to the agent subprocess as `ANTHROPIC_API_KEY`.

### 3. Open the Docs Overlay panel

Click the **weAudit** icon in the activity bar and expand the **Docs Overlay** view, or run
the command **Open Docs Overlay** (`weAudit.generateDocOverlay`) from the command palette.

### 4. Fill in the panel fields

| Field | What to enter |
|-------|---------------|
| **Claude Binary** | Path to the `claude` CLI binary. Auto-detected on panel open from `$CLAUDE_BINARY`, the Claude Code VS Code extension config, and common install paths (`~/.local/bin`, `/usr/local/bin`, Homebrew, etc.). |
| **Skill Name** | The slash-command name of your documentation skill, e.g. `user-journey-analyzer`. |
| **Plugin Directory** | Absolute path to the local plugin directory containing the skill. Click **…** to browse. |
| **Target Directory** | Directory to document. The agent reads every source file under this path. Click **…** to browse. |

### 5. Click Generate Docs

A VS Code progress notification appears while the agent runs. The scrollable log at the bottom
of the panel shows each agent round, tool calls, and any assistant thinking. Click **Cancel**
in the notification to abort early.

When generation finishes, inline ghost text appears immediately in open editors and in any
file you open that has been documented.

### 6. Managing overlays

The two action buttons in the panel become active once documentation exists:

- **Toggle Overlay** — show or hide ghost text across all editors. Teal when visible, muted
  when hidden. Keyboard-accessible via `weAudit.toggleDocOverlay`.
- **Clear Docs** — deletes all saved sessions and removes decorations. A confirmation dialog
  prevents accidental removal. Accessible via `weAudit.clearDocOverlay`.

Hover over any decorated line to see the full markdown document for that function or region
in a VS Code hover tooltip.

## The Claude skill requirement

The agent does not generate documentation by itself. It invokes a skill via a slash command
(e.g. `/<skillName>`) that you supply. The skill defines what the documentation looks like:
audit-focused analysis, API documentation, user journey summaries, or any other format.

A skill is a local Claude Code plugin — a directory containing a `skill.md` or equivalent
file that Claude Code registers as a slash command. The plugin directory is passed to the
agent via the `plugins` option of `@anthropic-ai/claude-agent-sdk`.

The agent receives Read, Glob, and Grep tools and autonomously explores the target directory.
It is instructed to output a JSON array of documentation entries with the following schema:

```json
[
  {
    "type": "function" | "file",
    "path": "<path relative to workspace root>",
    "startLine": 0,
    "endLine": 10,
    "functionName": "<name if type is function>",
    "summary": "<1-2 sentence summary for inline ghost text>",
    "fullDoc": "<full markdown documentation>",
    "generatedAt": "<ISO 8601 timestamp>",
    "skill": "<skill name>"
  }
]
```

The `summary` field is shown as inline ghost text. The `fullDoc` field is shown in hover
tooltips using VS Code's `MarkdownString` renderer.

## Persistence

Each generation run produces one session file in `weaudit-docs/doc-<hash>.json` inside the
workspace. Sessions accumulate — running the agent on different target directories adds entries
without removing previous ones. The watcher on `weaudit-docs/` picks up externally copied
session files automatically, so teammates can share generated docs by committing the directory.

The `weAudit.docOverlay.visibleOnLoad` setting (default: `true`) controls whether overlays
are shown when the workspace opens.

## New dependencies

| Package | Version | Purpose |
|---------|---------|---------|
| `@anthropic-ai/claude-agent-sdk` | `^0.2.47` | Runs the Claude Code subprocess via `query()` |

The SDK is a runtime dependency. No other new packages were added.

## New VS Code contribution points

| Type | ID | Description |
|------|----|-------------|
| View | `docsOverlay` | Sidebar webview panel in the weAudit activity bar |
| Command | `weAudit.generateDocOverlay` | Open Docs Overlay panel |
| Command | `weAudit.toggleDocOverlay` | Toggle Documentation Overlay Visibility |
| Command | `weAudit.clearDocOverlay` | Clear All Documentation Overlays |
| Setting | `weAudit.docOverlay.anthropicApiKey` | Anthropic API key for the agent |
| Setting | `weAudit.docOverlay.visibleOnLoad` | Show overlays when workspace opens |
