### PR TITLE
feat: add Code Quality finding type with comment-on-issue workflow

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -79,7 +79,11 @@ const watchPlugin = {
             console.log("build complete");
         }
     } catch (err) {
-        process.stderr.write(err.stderr);
+        if (err.stderr) {
+            process.stderr.write(err.stderr);
+        } else {
+            console.error(err);
+        }
         process.exit(1);
     }
 })();

--- a/package.json
+++ b/package.json
@@ -272,6 +272,10 @@
             {
                 "command": "weAudit.boundaryMoveDown",
                 "title": "weAudit: Move Finding Down"
+            },
+            {
+                "command": "weAudit.editCodeQualityIssueNumber",
+                "title": "weAudit: Set Code Quality Issue Number"
             }
         ],
         "keybindings": [
@@ -601,6 +605,11 @@
                         "type": "boolean",
                         "default": false,
                         "description": "Sort findings and notes alphabetically by name in the tree view."
+                    },
+                    "weAudit.general.skipCodeQualityConfirmation": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Skip the confirmation dialog when opening a Code Quality comment. The comment will be copied to clipboard and the issue opened immediately."
                     }
                 }
             },

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -75,6 +75,9 @@ class WARoot {
     // markedFilesDayLog contains a map associating a string representing a date to a file path.
     public markedFilesDayLog: Map<string, string[]>;
 
+    /** The GitHub issue number designated for Code Quality comments in this workspace root. */
+    public codeQualityIssueNumber: number | undefined;
+
     // firstTimeRequestingClientRemote is used to prevent repeatedly asking for the client remote
     private firstTimeRequestingClientRemote = true;
 
@@ -892,6 +895,9 @@ class WARoot {
             if (parsedEntries.gitSha !== undefined) {
                 this.gitSha = parsedEntries.gitSha;
             }
+            if (parsedEntries.codeQualityIssueNumber !== undefined) {
+                this.codeQualityIssueNumber = parsedEntries.codeQualityIssueNumber;
+            }
         }
 
         for (const entry of parsedEntries.treeEntries) {
@@ -1026,19 +1032,19 @@ class WARoot {
         // this means we are deleting the last element
         if (toCreateData || existsFile) {
             // save findings to file
-            const data = JSON.stringify(
-                {
-                    clientRemote: this.clientRemote,
-                    gitRemote: this.gitRemote,
-                    gitSha: this.gitSha,
-                    treeEntries: reducedEntries,
-                    auditedFiles: filteredAuditedFiles,
-                    partiallyAuditedFiles: filteredPartiallyAuditedEntries,
-                    resolvedEntries: reducedResolvedEntries,
-                },
-                null,
-                2,
-            );
+            const serializedObj: Record<string, unknown> = {
+                clientRemote: this.clientRemote,
+                gitRemote: this.gitRemote,
+                gitSha: this.gitSha,
+                treeEntries: reducedEntries,
+                auditedFiles: filteredAuditedFiles,
+                partiallyAuditedFiles: filteredPartiallyAuditedEntries,
+                resolvedEntries: reducedResolvedEntries,
+            };
+            if (this.codeQualityIssueNumber !== undefined) {
+                serializedObj.codeQualityIssueNumber = this.codeQualityIssueNumber;
+            }
+            const data = JSON.stringify(serializedObj, null, 2);
 
             fs.writeFileSync(fileName, data, { flag: "w+" });
         }
@@ -1049,11 +1055,17 @@ class WARoot {
      * @param clientRemote The client remote to be configured.
      * @param auditRemote The audit remote to be configured.
      * @param gitSha The git SHA digest to be configured.
+     * @param cqIssueNumber The Code Quality issue number (as string), or empty to clear.
      */
-    updateGitConfig(clientRemote: string, auditRemote: string, gitSha: string): void {
+    updateGitConfig(clientRemote: string, auditRemote: string, gitSha: string, cqIssueNumber?: string): void {
         this.clientRemote = clientRemote;
         this.gitRemote = auditRemote;
         this.gitSha = gitSha;
+
+        if (cqIssueNumber !== undefined) {
+            const parsed = Number(cqIssueNumber);
+            this.codeQualityIssueNumber = cqIssueNumber !== "" && Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+        }
 
         // persist the data
         void this.updateSavedData(this.username);
@@ -1355,12 +1367,12 @@ class MultiRootManager {
      * @param auditRemote The audit remote to be configured.
      * @param gitSha the git SHA to be configured.
      */
-    updateGitConfig(rootPath: string, clientRemote: string, auditRemote: string, gitSha: string): void {
+    updateGitConfig(rootPath: string, clientRemote: string, auditRemote: string, gitSha: string, cqIssueNumber?: string): void {
         const [wsRoot, _relativePath] = this.getCorrespondingRootAndPath(rootPath);
         if (wsRoot === undefined) {
             return;
         }
-        return wsRoot.updateGitConfig(clientRemote, auditRemote, gitSha);
+        return wsRoot.updateGitConfig(clientRemote, auditRemote, gitSha, cqIssueNumber);
     }
 
     /**
@@ -1681,6 +1693,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                     wsRoot.clientRemote,
                     wsRoot.gitRemote,
                     wsRoot.gitSha,
+                    wsRoot.codeQualityIssueNumber !== undefined ? String(wsRoot.codeQualityIssueNumber) : "",
                 );
             },
             this,
@@ -1825,6 +1838,10 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             void this.workspaces.editGitHash();
         });
 
+        vscode.commands.registerCommand("weAudit.editCodeQualityIssueNumber", () => {
+            void this.editCodeQualityIssueNumber();
+        });
+
         // Set up the repositories for one workspace root specified by its path
         vscode.commands.registerCommand("weAudit.setupRepositoriesOne", (rootPath: string) => {
             const [wsRoot, _relativePath] = this.workspaces.getCorrespondingRootAndPath(rootPath);
@@ -1898,7 +1915,11 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             }
 
             for (const actualEntry of actualEntries) {
-                void this.openGithubIssue(actualEntry);
+                if (actualEntry.details.type === FindingType.CodeQuality) {
+                    void this.openCodeQualityComment(actualEntry);
+                } else {
+                    void this.openGithubIssue(actualEntry);
+                }
             }
         });
 
@@ -1932,9 +1953,12 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             this.updateCurrentlySelectedEntry(field, value, isPersistent);
         });
 
-        vscode.commands.registerCommand("weAudit.updateGitConfig", (rootPath: string, clientRemote: string, auditRemote: string, gitSha: string) => {
-            this.workspaces.updateGitConfig(rootPath, clientRemote, auditRemote, gitSha);
-        });
+        vscode.commands.registerCommand(
+            "weAudit.updateGitConfig",
+            (rootPath: string, clientRemote: string, auditRemote: string, gitSha: string, cqIssueNumber?: string) => {
+                this.workspaces.updateGitConfig(rootPath, clientRemote, auditRemote, gitSha, cqIssueNumber);
+            },
+        );
 
         // This command is used by Sarif Explorer and requires to accept Entry for backwards compatibility
         vscode.commands.registerCommand("weAudit.externallyLoadFindings", (results: Entry[]) => {
@@ -2862,6 +2886,261 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             issueBodyText += `Client PermaLink:\n${clientPermalinkString}\n`;
         }
         return issueBodyText;
+    }
+
+    /**
+     * Generates simplified markdown for a Code Quality finding comment.
+     * Only includes title, description, location descriptions, and permalinks.
+     * @param entry The Code Quality finding entry
+     * @returns The markdown string or undefined if permalink generation fails
+     */
+    private async getCQCommentMarkdown(entry: FullEntry): Promise<string | void> {
+        const clientPermalinks = [];
+        const auditPermalinks = [];
+        let locationDescriptions = "";
+
+        let atLeastOneUniqueClientRemote = false;
+
+        for (const [i, location] of entry.locations.entries()) {
+            const clientRemoteAndPermalink = await this.getRemoteAndPermalink(Repository.Client, location);
+            const auditRemoteAndPermalink = await this.getRemoteAndPermalink(Repository.Audit, location);
+            if (auditRemoteAndPermalink === undefined) {
+                return;
+            }
+            if (
+                clientRemoteAndPermalink !== undefined &&
+                clientRemoteAndPermalink.remote !== "" &&
+                clientRemoteAndPermalink.remote !== auditRemoteAndPermalink.remote
+            ) {
+                atLeastOneUniqueClientRemote = true;
+            }
+            const clientPermalink = clientRemoteAndPermalink === undefined ? "" : clientRemoteAndPermalink.permalink;
+            clientPermalinks.push(clientPermalink);
+            auditPermalinks.push(auditRemoteAndPermalink.permalink);
+
+            if (location.label !== "" || location.description !== "") {
+                locationDescriptions += `\n\n---\n`;
+                locationDescriptions += `#### Location ${i + 1} ${location.label ?? ""}\n`;
+                if (location.description !== "") {
+                    locationDescriptions += `${location.description}\n\n`;
+                }
+                locationDescriptions += `${auditRemoteAndPermalink.permalink}`;
+            }
+        }
+
+        const permalinks = auditPermalinks.join("\n");
+        const clientPermalinkString = clientPermalinks.join("\n");
+
+        let bodyText = `### Title\n${entry.label}\n\n`;
+        bodyText += `## Description\n${entry.details.description}${locationDescriptions}\n\n`;
+        bodyText += `Permalink:\n${permalinks}\n\n`;
+        if (clientPermalinkString !== "" && atLeastOneUniqueClientRemote) {
+            bodyText += `Client PermaLink:\n${clientPermalinkString}\n`;
+        }
+        return bodyText;
+    }
+
+    /**
+     * Opens a Code Quality comment flow: copies comment markdown to clipboard
+     * and opens the designated GitHub issue page. If no issue number is configured,
+     * prompts the user to enter one or create a new issue first.
+     * @param entry The Code Quality finding entry
+     */
+    async openCodeQualityComment(entry: FullEntry): Promise<void> {
+        // Find the workspace root for the entry
+        let wsRoot: WARoot | undefined;
+        for (const loc of entry.locations) {
+            const [_wsRoot] = this.workspaces.getCorrespondingRootAndPath(loc.rootPath);
+            if (_wsRoot !== undefined) {
+                wsRoot = _wsRoot;
+                break;
+            }
+        }
+
+        if (wsRoot === undefined) {
+            vscode.window.showErrorMessage("weAudit: Error opening Code Quality comment. None of the locations correspond to a workspace root.");
+            return;
+        }
+
+        // Generate the CQ comment markdown (getRemoteAndPermalink handles missing remote with a config prompt)
+        const commentBody = await this.getCQCommentMarkdown(entry);
+        if (commentBody === undefined) {
+            return;
+        }
+
+        // Check if another workspace root with the same audit repo has a CQ issue number
+        if (wsRoot.codeQualityIssueNumber === undefined) {
+            for (const root of this.workspaces.getRoots()) {
+                if (root !== wsRoot && root.gitRemote === wsRoot.gitRemote && root.codeQualityIssueNumber !== undefined) {
+                    wsRoot.codeQualityIssueNumber = root.codeQualityIssueNumber;
+                    void wsRoot.updateSavedData(
+                        vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
+                    );
+                    break;
+                }
+            }
+        }
+
+        // If no CQ issue number is set, prompt the user
+        if (wsRoot.codeQualityIssueNumber === undefined) {
+            const choice = await vscode.window.showQuickPick(
+                ["Enter existing issue number", "Create a new issue"],
+                { placeHolder: "No Code Quality issue configured. How would you like to proceed?" },
+            );
+
+            if (choice === undefined) {
+                return;
+            }
+
+            if (choice === "Create a new issue") {
+                // Open browser to create a new issue with a generic description
+                const title = encodeURIComponent("Code Quality");
+                const issueBody =
+                    "This issue collects Code Quality findings for this audit.\n" +
+                    "Each finding is posted as a separate comment using the following template:\n\n" +
+                    "```\n" +
+                    "### Title\n" +
+                    "{finding title}\n\n" +
+                    "## Description\n" +
+                    "{finding description}\n\n" +
+                    "Permalink:\n" +
+                    "{audit permalink(s)}\n\n" +
+                    "Client PermaLink:\n" +
+                    "{client permalink(s)}\n" +
+                    "```\n";
+                const body = encodeURIComponent(issueBody);
+                const isGitHub = wsRoot.gitRemote.startsWith("https://github.com/") || wsRoot.gitRemote.startsWith("github.com/");
+                let issueUrl: string;
+                if (isGitHub) {
+                    issueUrl = `${wsRoot.gitRemote}/issues/new?title=${title}&body=${body}`;
+                } else {
+                    issueUrl = `${wsRoot.gitRemote}/-/issues/new?issue[title]=${title}&issue[description]=${body}`;
+                }
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                vscode.env.openExternal(issueUrl);
+
+                // Prompt for the resulting issue number
+                const issueNumberStr = await vscode.window.showInputBox({
+                    prompt: "Enter the issue number that was just created",
+                    ignoreFocusOut: true,
+                    validateInput: (value) => {
+                        const num = Number(value);
+                        if (!Number.isInteger(num) || num <= 0) {
+                            return "Please enter a valid positive integer";
+                        }
+                        return undefined;
+                    },
+                });
+                if (issueNumberStr === undefined) {
+                    return;
+                }
+                wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
+                void wsRoot.updateSavedData(
+                    vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
+                );
+                // Fall through to the clipboard+comment flow for this first finding
+            }
+
+            // "Enter existing issue number"
+            const issueNumberStr = await vscode.window.showInputBox({
+                prompt: "Enter the Code Quality issue number",
+                ignoreFocusOut: true,
+                validateInput: (value) => {
+                    const num = Number(value);
+                    if (!Number.isInteger(num) || num <= 0) {
+                        return "Please enter a valid positive integer";
+                    }
+                    return undefined;
+                },
+            });
+            if (issueNumberStr === undefined) {
+                return;
+            }
+            wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
+            void wsRoot.updateSavedData(
+                vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
+            );
+        }
+
+        const skipConfirmation: boolean = vscode.workspace.getConfiguration("weAudit").get("general.skipCodeQualityConfirmation", false);
+
+        if (!skipConfirmation) {
+            // Prompt the user before copying and opening, consistent with the too-long-URL fallback in openGithubIssue
+            const action = await vscode.window.showInformationMessage(
+                `Code Quality comment will be copied to clipboard and issue #${wsRoot.codeQualityIssueNumber} will be opened in the browser. ` +
+                    `You can disable this confirmation in Settings → weAudit: Skip Code Quality Confirmation.`,
+                "Copy comment and open issue",
+            );
+            if (action === undefined) {
+                return;
+            }
+        }
+
+        await vscode.env.clipboard.writeText(commentBody);
+        const issuePageUrl = `${wsRoot.gitRemote}/issues/${wsRoot.codeQualityIssueNumber}#sr-footer-heading`;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        vscode.env.openExternal(issuePageUrl);
+    }
+
+    /**
+     * Prompts the user to set or change the Code Quality issue number for the active workspace root.
+     */
+    private async editCodeQualityIssueNumber(): Promise<void> {
+        const roots = this.workspaces.getRoots();
+        if (roots.length === 0) {
+            vscode.window.showErrorMessage("weAudit: No workspace roots available.");
+            return;
+        }
+
+        let wsRoot: WARoot;
+        if (roots.length === 1) {
+            wsRoot = roots[0];
+        } else {
+            const rootPaths = roots.map((r) => r.rootPath);
+            const selected = await vscode.window.showQuickPick(rootPaths, {
+                placeHolder: "Select a workspace root",
+            });
+            if (selected === undefined) {
+                return;
+            }
+            const [foundRoot] = this.workspaces.getCorrespondingRootAndPath(selected);
+            if (foundRoot === undefined) {
+                return;
+            }
+            wsRoot = foundRoot;
+        }
+
+        const currentValue = wsRoot.codeQualityIssueNumber;
+        const issueNumberStr = await vscode.window.showInputBox({
+            prompt: "Enter the Code Quality GitHub issue number",
+            value: currentValue !== undefined ? String(currentValue) : "",
+            validateInput: (value) => {
+                if (value === "") {
+                    return undefined; // allow clearing
+                }
+                const num = Number(value);
+                if (!Number.isInteger(num) || num <= 0) {
+                    return "Please enter a valid positive integer or leave empty to clear";
+                }
+                return undefined;
+            },
+        });
+        if (issueNumberStr === undefined) {
+            return;
+        }
+
+        wsRoot.codeQualityIssueNumber = issueNumberStr === "" ? undefined : Number(issueNumberStr);
+        void wsRoot.updateSavedData(
+            vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
+        );
+
+        if (wsRoot.codeQualityIssueNumber !== undefined) {
+            vscode.window.showInformationMessage(`Code Quality issue number set to #${wsRoot.codeQualityIssueNumber}.`);
+        } else {
+            vscode.window.showInformationMessage("Code Quality issue number cleared.");
+        }
     }
 
     /**
@@ -4415,7 +4694,11 @@ export class AuditMarker {
             if (entry === undefined) {
                 return;
             }
-            void treeDataProvider.openGithubIssue(entry);
+            if (entry.details.type === FindingType.CodeQuality) {
+                void treeDataProvider.openCodeQualityComment(entry);
+            } else {
+                void treeDataProvider.openGithubIssue(entry);
+            }
         });
 
         // Activate the finding boundary CodeLens feature

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -2973,9 +2973,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             for (const root of this.workspaces.getRoots()) {
                 if (root !== wsRoot && root.gitRemote === wsRoot.gitRemote && root.codeQualityIssueNumber !== undefined) {
                     wsRoot.codeQualityIssueNumber = root.codeQualityIssueNumber;
-                    void wsRoot.updateSavedData(
-                        vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
-                    );
+                    void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
                     break;
                 }
             }
@@ -2983,10 +2981,9 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
 
         // If no CQ issue number is set, prompt the user
         if (wsRoot.codeQualityIssueNumber === undefined) {
-            const choice = await vscode.window.showQuickPick(
-                ["Enter existing issue number", "Create a new issue"],
-                { placeHolder: "No Code Quality issue configured. How would you like to proceed?" },
-            );
+            const choice = await vscode.window.showQuickPick(["Enter existing issue number", "Create a new issue"], {
+                placeHolder: "No Code Quality issue configured. How would you like to proceed?",
+            });
 
             if (choice === undefined) {
                 return;
@@ -3036,9 +3033,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                     return;
                 }
                 wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
-                void wsRoot.updateSavedData(
-                    vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
-                );
+                void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
                 // Fall through to the clipboard+comment flow for this first finding
             }
 
@@ -3058,9 +3053,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                 return;
             }
             wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
-            void wsRoot.updateSavedData(
-                vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
-            );
+            void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
         }
 
         const skipConfirmation: boolean = vscode.workspace.getConfiguration("weAudit").get("general.skipCodeQualityConfirmation", false);
@@ -3132,9 +3125,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         }
 
         wsRoot.codeQualityIssueNumber = issueNumberStr === "" ? undefined : Number(issueNumberStr);
-        void wsRoot.updateSavedData(
-            vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username,
-        );
+        void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
 
         if (wsRoot.codeQualityIssueNumber !== undefined) {
             vscode.window.showInformationMessage(`Code Quality issue number set to #${wsRoot.codeQualityIssueNumber}.`);

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -1915,7 +1915,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
             }
 
             for (const actualEntry of actualEntries) {
-                if (actualEntry.details.type === FindingType.CodeQuality) {
+                if (actualEntry.details.severity === FindingSeverity.CodeQuality) {
                     void this.openCodeQualityComment(actualEntry);
                 } else {
                     void this.openGithubIssue(actualEntry);
@@ -2982,6 +2982,8 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         // If no CQ issue number is set, prompt the user
         if (wsRoot.codeQualityIssueNumber === undefined) {
             const choice = await vscode.window.showQuickPick(["Enter existing issue number", "Create a new issue"], {
+                ignoreFocusOut: true,
+                title: "Code Quality Issue Setup",
                 placeHolder: "No Code Quality issue configured. How would you like to proceed?",
             });
 
@@ -3061,10 +3063,14 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         if (!skipConfirmation) {
             // Prompt the user before copying and opening, consistent with the too-long-URL fallback in openGithubIssue
             const action = await vscode.window.showInformationMessage(
-                `Code Quality comment will be copied to clipboard and issue #${wsRoot.codeQualityIssueNumber} will be opened in the browser. ` +
-                    `You can disable this confirmation in Settings → weAudit: Skip Code Quality Confirmation.`,
+                `Code Quality comment will be copied to clipboard and issue #${wsRoot.codeQualityIssueNumber} will be opened in the browser.`,
                 "Copy comment and open issue",
+                "Open Settings",
             );
+            if (action === "Open Settings") {
+                void vscode.commands.executeCommand("workbench.action.openSettings", "weAudit.general.skipCodeQualityConfirmation");
+                return;
+            }
             if (action === undefined) {
                 return;
             }
@@ -3093,6 +3099,8 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         } else {
             const rootPaths = roots.map((r) => r.rootPath);
             const selected = await vscode.window.showQuickPick(rootPaths, {
+                ignoreFocusOut: true,
+                title: "Select Workspace Root",
                 placeHolder: "Select a workspace root",
             });
             if (selected === undefined) {
@@ -4685,7 +4693,7 @@ export class AuditMarker {
             if (entry === undefined) {
                 return;
             }
-            if (entry.details.type === FindingType.CodeQuality) {
+            if (entry.details.severity === FindingSeverity.CodeQuality) {
                 void treeDataProvider.openCodeQualityComment(entry);
             } else {
                 void treeDataProvider.openGithubIssue(entry);

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -3063,7 +3063,7 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         if (!skipConfirmation) {
             // Prompt the user before copying and opening, consistent with the too-long-URL fallback in openGithubIssue
             const action = await vscode.window.showInformationMessage(
-                `Code Quality comment will be copied to clipboard and issue #${wsRoot.codeQualityIssueNumber} will be opened in the browser.`,
+                `Code Quality comment will be copied to clipboard and issue #${wsRoot.codeQualityIssueNumber} will be opened in the browser. To skip this dialog in the future, you can change the behavior in Settings.`,
                 "Copy comment and open issue",
                 "Open Settings",
             );

--- a/src/codeMarker.ts
+++ b/src/codeMarker.ts
@@ -3037,25 +3037,25 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
                 wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
                 void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
                 // Fall through to the clipboard+comment flow for this first finding
+            } else {
+                // "Enter existing issue number"
+                const issueNumberStr = await vscode.window.showInputBox({
+                    prompt: "Enter the Code Quality issue number",
+                    ignoreFocusOut: true,
+                    validateInput: (value) => {
+                        const num = Number(value);
+                        if (!Number.isInteger(num) || num <= 0) {
+                            return "Please enter a valid positive integer";
+                        }
+                        return undefined;
+                    },
+                });
+                if (issueNumberStr === undefined) {
+                    return;
+                }
+                wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
+                void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
             }
-
-            // "Enter existing issue number"
-            const issueNumberStr = await vscode.window.showInputBox({
-                prompt: "Enter the Code Quality issue number",
-                ignoreFocusOut: true,
-                validateInput: (value) => {
-                    const num = Number(value);
-                    if (!Number.isInteger(num) || num <= 0) {
-                        return "Please enter a valid positive integer";
-                    }
-                    return undefined;
-                },
-            });
-            if (issueNumberStr === undefined) {
-                return;
-            }
-            wsRoot.codeQualityIssueNumber = Number(issueNumberStr);
-            void wsRoot.updateSavedData(vscode.workspace.getConfiguration("weAudit").get("general.username") || userInfo().username);
         }
 
         const skipConfirmation: boolean = vscode.workspace.getConfiguration("weAudit").get("general.skipCodeQualityConfirmation", false);
@@ -3077,7 +3077,10 @@ export class CodeMarker implements vscode.TreeDataProvider<TreeEntry> {
         }
 
         await vscode.env.clipboard.writeText(commentBody);
-        const issuePageUrl = `${wsRoot.gitRemote}/issues/${wsRoot.codeQualityIssueNumber}#sr-footer-heading`;
+        const isGitHub = wsRoot.gitRemote.startsWith("https://github.com/") || wsRoot.gitRemote.startsWith("github.com/");
+        const issuePageUrl = isGitHub
+            ? `${wsRoot.gitRemote}/issues/${wsRoot.codeQualityIssueNumber}#sr-footer-heading`
+            : `${wsRoot.gitRemote}/-/issues/${wsRoot.codeQualityIssueNumber}`;
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         vscode.env.openExternal(issuePageUrl);

--- a/src/panels/findingDetails.html
+++ b/src/panels/findingDetails.html
@@ -31,6 +31,7 @@
         <span class="detailSpan">Type:</span>
         <vscode-dropdown position="below" id="type-dropdown" width="100%">
             <vscode-option></vscode-option>
+            <vscode-option>Code Quality</vscode-option>
             <vscode-option>Access Controls</vscode-option>
             <vscode-option>Auditing and Logging</vscode-option>
             <vscode-option>Authentication</vscode-option>

--- a/src/panels/findingDetails.html
+++ b/src/panels/findingDetails.html
@@ -13,6 +13,7 @@
             <vscode-option>Low</vscode-option>
             <vscode-option>Medium</vscode-option>
             <vscode-option>High</vscode-option>
+            <vscode-option>Code Quality</vscode-option>
         </vscode-dropdown>
     </div>
 
@@ -31,7 +32,6 @@
         <span class="detailSpan">Type:</span>
         <vscode-dropdown position="below" id="type-dropdown" width="100%">
             <vscode-option></vscode-option>
-            <vscode-option>Code Quality</vscode-option>
             <vscode-option>Access Controls</vscode-option>
             <vscode-option>Auditing and Logging</vscode-option>
             <vscode-option>Authentication</vscode-option>

--- a/src/panels/findingDetails.html
+++ b/src/panels/findingDetails.html
@@ -8,12 +8,12 @@
         <span class="detailSpan">Severity:</span>
         <vscode-dropdown position="below" id="severity-dropdown">
             <vscode-option></vscode-option>
+            <vscode-option>Code Quality</vscode-option>
             <vscode-option>Informational</vscode-option>
             <vscode-option>Undetermined</vscode-option>
             <vscode-option>Low</vscode-option>
             <vscode-option>Medium</vscode-option>
             <vscode-option>High</vscode-option>
-            <vscode-option>Code Quality</vscode-option>
         </vscode-dropdown>
     </div>
 

--- a/src/panels/gitConfig.html
+++ b/src/panels/gitConfig.html
@@ -16,4 +16,9 @@
         <span class="detailSpan">Commit Hash:</span>
         <vscode-text-field id="commit-hash"></vscode-text-field>
     </div>
+
+    <div class="detailsDiv">
+        <span class="detailSpan">Code Quality Issue #:</span>
+        <vscode-text-field id="cq-issue-number" placeholder="e.g. 42"></vscode-text-field>
+    </div>
 </div>

--- a/src/panels/gitConfigPanel.ts
+++ b/src/panels/gitConfigPanel.ts
@@ -26,7 +26,7 @@ class GitConfigProvider implements vscode.WebviewViewProvider {
 
         vscode.commands.registerCommand(
             "weAudit.setGitConfigView",
-            (rootPathAndLabel: RootPathAndLabel, clientRepo: string, auditRepo: string, commitHash: string) => {
+            (rootPathAndLabel: RootPathAndLabel, clientRepo: string, auditRepo: string, commitHash: string, cqIssueNumber?: string) => {
                 this.currentRootPathAndLabel = rootPathAndLabel;
                 const msg: UpdateRepositoryMessage = {
                     command: "update-repository-config",
@@ -34,6 +34,7 @@ class GitConfigProvider implements vscode.WebviewViewProvider {
                     clientURL: clientRepo,
                     auditURL: auditRepo,
                     commitHash,
+                    cqIssueNumber: cqIssueNumber ?? "",
                 };
                 this._view?.webview.postMessage(msg);
             },
@@ -142,7 +143,14 @@ class GitConfigProvider implements vscode.WebviewViewProvider {
                             );
                             return;
                         }
-                        vscode.commands.executeCommand("weAudit.updateGitConfig", rootPath, message.clientURL, message.auditURL, message.commitHash);
+                        vscode.commands.executeCommand(
+                            "weAudit.updateGitConfig",
+                            rootPath,
+                            message.clientURL,
+                            message.auditURL,
+                            message.commitHash,
+                            message.cqIssueNumber,
+                        );
                         return;
                     case "choose-workspace-root":
                         rootPath = this.dirToPathMap.get(message.rootLabel);

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export enum FindingSeverity {
     Low = "Low",
     Medium = "Medium",
     High = "High",
+    CodeQuality = "Code Quality",
     Undefined = "",
 }
 
@@ -64,7 +65,6 @@ export enum FindingType {
     Testing = "Testing",
     Timing = "Timing",
     UndefinedBehavior = "Undefined Behavior",
-    CodeQuality = "Code Quality",
     Undefined = "",
 }
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export enum FindingType {
     Testing = "Testing",
     Timing = "Timing",
     UndefinedBehavior = "Undefined Behavior",
+    CodeQuality = "Code Quality",
     Undefined = "",
 }
 /* eslint-enable @typescript-eslint/naming-convention */
@@ -89,6 +90,8 @@ export interface SerializedData {
     // older versions do not have partiallyAuditedFiles
     partiallyAuditedFiles?: PartiallyAuditedFile[];
     resolvedEntries: Entry[];
+    // optional code quality issue number for the workspace root
+    codeQualityIssueNumber?: number;
 }
 
 /**
@@ -104,6 +107,8 @@ export interface FullSerializedData {
     // older versions do not have partiallyAuditedFiles
     partiallyAuditedFiles?: PartiallyAuditedFile[];
     resolvedEntries: FullEntry[];
+    // optional code quality issue number for the workspace root
+    codeQualityIssueNumber?: number;
 }
 
 /**

--- a/src/webview/findingDetailsMain.ts
+++ b/src/webview/findingDetailsMain.ts
@@ -25,16 +25,16 @@ function main(): void {
     titleField?.addEventListener("change", handlePersistentFieldChange);
 
     const severityDropdown = document.getElementById("severity-dropdown") as Dropdown;
-    severityDropdown?.addEventListener("change", handlePersistentFieldChange);
+    severityDropdown?.addEventListener("change", (e: Event) => {
+        handlePersistentFieldChange(e);
+        updateFieldVisibility(severityDropdown.value);
+    });
 
     const difficultyDropdown = document.getElementById("difficulty-dropdown") as Dropdown;
     difficultyDropdown?.addEventListener("change", handlePersistentFieldChange);
 
     const typeDropdown = document.getElementById("type-dropdown") as Dropdown;
-    typeDropdown?.addEventListener("change", (e: Event) => {
-        handlePersistentFieldChange(e);
-        updateFieldVisibility(typeDropdown.value);
-    });
+    typeDropdown?.addEventListener("change", handlePersistentFieldChange);
 
     // for the text areas, we listen to to both the change and input events
     // on change events we persist the data into disk
@@ -74,7 +74,7 @@ function main(): void {
                 descriptionArea.value = message.description;
                 exploitArea.value = message.exploit;
                 recommendationArea.value = message.recommendation;
-                updateFieldVisibility(message.type as string);
+                updateFieldVisibility(message.severity as string);
                 break;
 
             case "hide-finding-details":
@@ -106,15 +106,15 @@ function handleFieldChange(e: Event, isPersistent: boolean): void {
     vscode.postMessage(message);
 }
 
-const CODE_QUALITY_TYPE = "Code Quality";
+const CODE_QUALITY_SEVERITY = "Code Quality";
 
 /**
- * Shows or hides detail fields based on whether the finding type is "Code Quality".
- * Code Quality findings only show title, type, and description.
+ * Shows or hides detail fields based on whether the finding severity is "Code Quality".
+ * Code Quality findings only show title, severity, and description.
  */
-function updateFieldVisibility(type: string): void {
-    const isCodeQuality = type === CODE_QUALITY_TYPE;
-    const hiddenIds = ["severity-dropdown", "difficulty-dropdown", "exploit-area", "recommendation-area"];
+function updateFieldVisibility(severity: string): void {
+    const isCodeQuality = severity === CODE_QUALITY_SEVERITY;
+    const hiddenIds = ["difficulty-dropdown", "type-dropdown", "exploit-area", "recommendation-area"];
     for (const id of hiddenIds) {
         const element = document.getElementById(id);
         const parentDiv = element?.parentElement;

--- a/src/webview/findingDetailsMain.ts
+++ b/src/webview/findingDetailsMain.ts
@@ -31,7 +31,10 @@ function main(): void {
     difficultyDropdown?.addEventListener("change", handlePersistentFieldChange);
 
     const typeDropdown = document.getElementById("type-dropdown") as Dropdown;
-    typeDropdown?.addEventListener("change", handlePersistentFieldChange);
+    typeDropdown?.addEventListener("change", (e: Event) => {
+        handlePersistentFieldChange(e);
+        updateFieldVisibility(typeDropdown.value);
+    });
 
     // for the text areas, we listen to to both the change and input events
     // on change events we persist the data into disk
@@ -71,6 +74,7 @@ function main(): void {
                 descriptionArea.value = message.description;
                 exploitArea.value = message.exploit;
                 recommendationArea.value = message.recommendation;
+                updateFieldVisibility(message.type as string);
                 break;
 
             case "hide-finding-details":
@@ -100,4 +104,22 @@ function handleFieldChange(e: Event, isPersistent: boolean): void {
         isPersistent: isPersistent,
     };
     vscode.postMessage(message);
+}
+
+const CODE_QUALITY_TYPE = "Code Quality";
+
+/**
+ * Shows or hides detail fields based on whether the finding type is "Code Quality".
+ * Code Quality findings only show title, type, and description.
+ */
+function updateFieldVisibility(type: string): void {
+    const isCodeQuality = type === CODE_QUALITY_TYPE;
+    const hiddenIds = ["severity-dropdown", "difficulty-dropdown", "exploit-area", "recommendation-area"];
+    for (const id of hiddenIds) {
+        const element = document.getElementById(id);
+        const parentDiv = element?.parentElement;
+        if (parentDiv) {
+            parentDiv.style.display = isCodeQuality ? "none" : "";
+        }
+    }
 }

--- a/src/webview/gitConfigMain.ts
+++ b/src/webview/gitConfigMain.ts
@@ -28,6 +28,9 @@ function main(): void {
     const commitHash = document.getElementById("commit-hash") as TextField;
     commitHash?.addEventListener("change", handleFieldChange);
 
+    const cqIssueNumber = document.getElementById("cq-issue-number") as TextField;
+    cqIssueNumber?.addEventListener("change", handleFieldChange);
+
     // handle the message inside the webview
     window.addEventListener("message", (event) => {
         const message = event.data;
@@ -39,6 +42,7 @@ function main(): void {
                 clientURL.value = message.clientURL;
                 auditURL.value = message.auditURL;
                 commitHash.value = message.commitHash;
+                cqIssueNumber.value = message.cqIssueNumber ?? "";
                 break;
 
             case "set-workspace-roots":
@@ -67,6 +71,7 @@ function handleFieldChange(_e: Event): void {
     const clientURL = document.getElementById("client-url") as TextField;
     const auditURL = document.getElementById("audit-url") as TextField;
     const commitHash = document.getElementById("commit-hash") as TextField;
+    const cqIssueNumber = document.getElementById("cq-issue-number") as TextField;
     const rootDropdown = document.getElementById("workspace-root-list-dropdown") as Dropdown;
 
     const message: UpdateRepositoryMessage = {
@@ -75,6 +80,7 @@ function handleFieldChange(_e: Event): void {
         clientURL: clientURL.value,
         auditURL: auditURL.value,
         commitHash: commitHash.value,
+        cqIssueNumber: cqIssueNumber.value,
     };
     vscode.postMessage(message);
 }

--- a/src/webview/webviewMessageTypes.ts
+++ b/src/webview/webviewMessageTypes.ts
@@ -13,6 +13,7 @@ export interface UpdateRepositoryMessage {
     clientURL: string;
     auditURL: string;
     commitHash: string;
+    cqIssueNumber: string;
 }
 
 export interface ChooseWorkspaceRootMessage {

--- a/test/extension/suite/activation.test.ts
+++ b/test/extension/suite/activation.test.ts
@@ -66,6 +66,8 @@ suite("Extension Activation", () => {
             // Git config commands
             "weAudit.editClientRemote",
             "weAudit.editAuditRemote",
+            // Code Quality commands
+            "weAudit.editCodeQualityIssueNumber",
             // Multi-root workspace commands
             "weAudit.nextGitConfig",
             "weAudit.prevGitConfig",

--- a/test/fixtures/code-quality.weaudit
+++ b/test/fixtures/code-quality.weaudit
@@ -8,9 +8,9 @@
             "entryType": 0,
             "author": "alice",
             "details": {
-                "severity": "",
+                "severity": "Code Quality",
                 "difficulty": "",
-                "type": "Code Quality",
+                "type": "",
                 "description": "The return value of this function call is not used.",
                 "exploit": "",
                 "recommendation": ""

--- a/test/fixtures/code-quality.weaudit
+++ b/test/fixtures/code-quality.weaudit
@@ -1,0 +1,55 @@
+{
+    "clientRemote": "https://github.com/client/project",
+    "gitRemote": "https://github.com/auditor/project-audit",
+    "gitSha": "abc123def456",
+    "treeEntries": [
+        {
+            "label": "Unused return value",
+            "entryType": 0,
+            "author": "alice",
+            "details": {
+                "severity": "",
+                "difficulty": "",
+                "type": "Code Quality",
+                "description": "The return value of this function call is not used.",
+                "exploit": "",
+                "recommendation": ""
+            },
+            "locations": [
+                {
+                    "path": "src/utils/helpers.ts",
+                    "startLine": 15,
+                    "endLine": 15,
+                    "label": "unused return",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "label": "SQL Injection in user input",
+            "entryType": 0,
+            "author": "alice",
+            "details": {
+                "severity": "High",
+                "difficulty": "Low",
+                "type": "Data Validation",
+                "description": "User input is not properly sanitized.",
+                "exploit": "An attacker could inject malicious SQL.",
+                "recommendation": "Use parameterized queries."
+            },
+            "locations": [
+                {
+                    "path": "src/database/queries.ts",
+                    "startLine": 42,
+                    "endLine": 45,
+                    "label": "executeQuery function",
+                    "description": ""
+                }
+            ]
+        }
+    ],
+    "auditedFiles": [],
+    "partiallyAuditedFiles": [],
+    "resolvedEntries": [],
+    "codeQualityIssueNumber": 99
+}

--- a/test/unit/types.test.ts
+++ b/test/unit/types.test.ts
@@ -628,23 +628,23 @@ describe("types.ts", () => {
         });
     });
 
-    describe("FindingType.CodeQuality", () => {
+    describe("FindingSeverity.CodeQuality", () => {
         it("should have CodeQuality enum value", () => {
-            assert.strictEqual(FindingType.CodeQuality, "Code Quality");
+            assert.strictEqual(FindingSeverity.CodeQuality, "Code Quality");
         });
 
         it("should be accepted by isEnumValue", () => {
-            assert.strictEqual(isEnumValue(FindingType, "Code Quality"), true);
+            assert.strictEqual(isEnumValue(FindingSeverity, "Code Quality"), true);
         });
 
-        it("should reject invalid finding type values", () => {
-            assert.strictEqual(isEnumValue(FindingType, "Not A Real Type"), false);
+        it("should reject invalid finding severity values", () => {
+            assert.strictEqual(isEnumValue(FindingSeverity, "Not A Real Severity"), false);
         });
 
-        it("should allow creating entry details with CodeQuality type", () => {
+        it("should allow creating entry details with CodeQuality severity", () => {
             const details = createDefaultEntryDetails();
-            details.type = FindingType.CodeQuality;
-            assert.strictEqual(details.type, "Code Quality");
+            details.severity = FindingSeverity.CodeQuality;
+            assert.strictEqual(details.severity, "Code Quality");
         });
     });
 
@@ -655,9 +655,9 @@ describe("types.ts", () => {
                 entryType: EntryType.Finding,
                 author: "testuser",
                 details: {
-                    severity: FindingSeverity.High,
+                    severity: FindingSeverity.CodeQuality,
                     difficulty: FindingDifficulty.Low,
-                    type: FindingType.CodeQuality,
+                    type: FindingType.Undefined,
                     description: "Test description",
                     exploit: "",
                     recommendation: "",

--- a/test/unit/validators.test.ts
+++ b/test/unit/validators.test.ts
@@ -461,4 +461,36 @@ describe("validateSerializedData", () => {
             expect(validateSerializedData(data)).to.equal(false);
         });
     });
+
+    describe("Code Quality finding type", () => {
+        it("accepts entry with FindingType.CodeQuality", () => {
+            const data = createDefaultSerializedData();
+            const entry = createValidEntry();
+            entry.details.type = FindingType.CodeQuality;
+            data.treeEntries = [entry];
+            expect(validateSerializedData(data)).to.equal(true);
+        });
+
+        it("accepts data with codeQualityIssueNumber field", () => {
+            const data: any = {
+                ...createValidSerializedData(),
+                codeQualityIssueNumber: 42,
+            };
+            expect(validateSerializedData(data)).to.equal(true);
+        });
+
+        it("accepts data without codeQualityIssueNumber (backwards compatibility)", () => {
+            const data = createValidSerializedData();
+            expect(data.codeQualityIssueNumber).to.be.undefined;
+            expect(validateSerializedData(data)).to.equal(true);
+        });
+
+        it("accepts Code Quality entry in resolvedEntries", () => {
+            const data = createDefaultSerializedData();
+            const entry = createValidEntry();
+            entry.details.type = FindingType.CodeQuality;
+            data.resolvedEntries = [entry];
+            expect(validateSerializedData(data)).to.equal(true);
+        });
+    });
 });

--- a/test/unit/validators.test.ts
+++ b/test/unit/validators.test.ts
@@ -462,11 +462,11 @@ describe("validateSerializedData", () => {
         });
     });
 
-    describe("Code Quality finding type", () => {
-        it("accepts entry with FindingType.CodeQuality", () => {
+    describe("Code Quality finding severity", () => {
+        it("accepts entry with FindingSeverity.CodeQuality", () => {
             const data = createDefaultSerializedData();
             const entry = createValidEntry();
-            entry.details.type = FindingType.CodeQuality;
+            entry.details.severity = FindingSeverity.CodeQuality;
             data.treeEntries = [entry];
             expect(validateSerializedData(data)).to.equal(true);
         });
@@ -488,7 +488,7 @@ describe("validateSerializedData", () => {
         it("accepts Code Quality entry in resolvedEntries", () => {
             const data = createDefaultSerializedData();
             const entry = createValidEntry();
-            entry.details.type = FindingType.CodeQuality;
+            entry.details.severity = FindingSeverity.CodeQuality;
             data.resolvedEntries = [entry];
             expect(validateSerializedData(data)).to.equal(true);
         });

--- a/test/webview/messageHandlers.test.ts
+++ b/test/webview/messageHandlers.test.ts
@@ -145,14 +145,27 @@ describe("Webview Message Handlers", () => {
                 if (message.command === "update-repository-config") {
                     const rootPath = dirToPathMap.get(message.rootLabel);
                     if (rootPath !== undefined) {
-                        commandExecutor.executeCommand("weAudit.updateGitConfig", rootPath, message.clientURL, message.auditURL, message.commitHash, message.cqIssueNumber);
+                        commandExecutor.executeCommand(
+                            "weAudit.updateGitConfig",
+                            rootPath,
+                            message.clientURL,
+                            message.auditURL,
+                            message.commitHash,
+                            message.cqIssueNumber,
+                        );
                     }
                 }
 
                 const commands = commandExecutor.getExecutedCommands();
                 expect(commands).to.have.length(1);
                 expect(commands[0].command).to.equal("weAudit.updateGitConfig");
-                expect(commands[0].args).to.deep.equal(["/workspace/project1", "https://github.com/client/repo", "https://github.com/audit/repo", "abc123", ""]);
+                expect(commands[0].args).to.deep.equal([
+                    "/workspace/project1",
+                    "https://github.com/client/repo",
+                    "https://github.com/audit/repo",
+                    "abc123",
+                    "",
+                ]);
             });
 
             it("shows error when rootLabel is not found in map", () => {

--- a/test/webview/messageHandlers.test.ts
+++ b/test/webview/messageHandlers.test.ts
@@ -138,20 +138,21 @@ describe("Webview Message Handlers", () => {
                     clientURL: "https://github.com/client/repo",
                     auditURL: "https://github.com/audit/repo",
                     commitHash: "abc123",
+                    cqIssueNumber: "",
                 };
 
                 // Simulate message handler
                 if (message.command === "update-repository-config") {
                     const rootPath = dirToPathMap.get(message.rootLabel);
                     if (rootPath !== undefined) {
-                        commandExecutor.executeCommand("weAudit.updateGitConfig", rootPath, message.clientURL, message.auditURL, message.commitHash);
+                        commandExecutor.executeCommand("weAudit.updateGitConfig", rootPath, message.clientURL, message.auditURL, message.commitHash, message.cqIssueNumber);
                     }
                 }
 
                 const commands = commandExecutor.getExecutedCommands();
                 expect(commands).to.have.length(1);
                 expect(commands[0].command).to.equal("weAudit.updateGitConfig");
-                expect(commands[0].args).to.deep.equal(["/workspace/project1", "https://github.com/client/repo", "https://github.com/audit/repo", "abc123"]);
+                expect(commands[0].args).to.deep.equal(["/workspace/project1", "https://github.com/client/repo", "https://github.com/audit/repo", "abc123", ""]);
             });
 
             it("shows error when rootLabel is not found in map", () => {
@@ -165,6 +166,7 @@ describe("Webview Message Handlers", () => {
                     clientURL: "https://github.com/client/repo",
                     auditURL: "https://github.com/audit/repo",
                     commitHash: "abc123",
+                    cqIssueNumber: "",
                 };
 
                 // Simulate message handler
@@ -299,6 +301,7 @@ describe("Webview Message Handlers", () => {
                 clientURL: "https://example.com",
                 auditURL: "https://example.com",
                 commitHash: "abc123",
+                cqIssueNumber: "",
             };
 
             expect(message.command).to.equal("update-repository-config");


### PR DESCRIPTION
Code Quality is a new value in the FindingType enum. When a finding has ~~type~~ severity "Code Quality", the details panel hides ~~severity~~ type, difficulty, exploit scenario, and recommendation fields. The "Open Remote Issue" flow posts a comment on a single designated GitHub issue instead of creating a new issue per finding. The CQ issue number is stored per-workspace-root, shared across sibling roots with the same audit repo, and editable from both the command palette and the Repository Configuration panel.

Implements #156