### PR TITLE
ci: trigger the release on a tag push and gate publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Build release and publish on VSCode's Marketplace and OpenVSX
 on:
-    release:
-        types: [published]
+    push:
+        tags:
+            - "v*"
 
 permissions:
     contents: read
@@ -30,7 +31,7 @@ jobs:
                   name: weaudit
                   path: weaudit.vsix
 
-    upload-asset:
+    create-release:
         runs-on: ubuntu-latest
         needs: build
         if: success()
@@ -41,15 +42,18 @@ jobs:
               with:
                   name: weaudit
 
-            - name: Upload vsix to release
-              uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-              with:
-                  files: weaudit.vsix
+            - name: Create the release with the vsix attached
+              run: gh release create "$TAG" weaudit.vsix --generate-notes --verify-tag
+              env:
+                  TAG: ${{ github.ref_name }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
 
     publish:
         runs-on: ubuntu-latest
-        needs: build
+        needs: create-release
         if: success()
+        environment: marketplace
         steps:
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:

--- a/README.md
+++ b/README.md
@@ -247,3 +247,7 @@ npx eslint -c .eslintrc.cjs .
 # run Biome formatter
 npx biome format --write .
 ```
+
+### Releasing
+
+The release process is detailed in [releasing.md](./docs/releasing.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,28 @@
+# Releasing weAudit
+
+A release is created by pushing a `v*` tag. The [publish workflow](../.github/workflows/publish.yml) builds the vsix, creates the GitHub release with the vsix attached, and publishes the extension to the VSCode Marketplace and to OpenVSX.
+
+1. Merge a PR that bumps `version` in `package.json`, running `npm install` to carry the version into `package-lock.json`.
+
+2. Tag the bump commit on `main` and push the tag:
+
+   ```bash
+   VERSION=v?.?.?
+
+   git checkout main && git pull
+   git tag "$VERSION"
+   git push origin "$VERSION"
+   ```
+
+3. Approve the deployment on the workflow run. The `publish` job waits for a reviewer, so nothing
+   reaches the Marketplace or OpenVSX until it is approved.
+
+Do not create the release through the GitHub web UI. Releases in this repository are immutable, so
+the vsix cannot be attached after the release is published.
+
+## Troubleshooting
+
+If the Marketplace step fails with `Access Denied: The Personal Access Token used has expired`,
+`WEAUDIT_VSCODE_MARKETPLACE_TOKEN` needs a new [Azure DevOps](https://dev.azure.com) token with the
+`Marketplace > Publish` scope. They are capped at one year. The OpenVSX equivalent is
+`WEAUDIT_OPENVSX_TOKEN`.


### PR DESCRIPTION
Attaching the vsix to an already published release stops working once immutable releases are enabled.

So the release is now cut by pushing a v* tag instead of through the web UI. The Marketplace and OpenVSX step also moves to the marketplace environment and to needs: create-release — it used to share needs: build with the asset upload, so it published in parallel even when attaching the vsix had failed.

Mirrors trailofbits/vscode-sarif-explorer#136.